### PR TITLE
Removed request to link to sqlite library (-lsqlite3) from Makefile a…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ARA_ROOT_FLAGS =
 # added for Fortran to C++
 
 
-LIBS	= $(ROOTLIBS) -lMinuit $(SYSLIBS) -lsqlite3
+LIBS	= $(ROOTLIBS) -lMinuit $(SYSLIBS)
 GLIBS	= $(ROOTGLIBS) $(SYSLIBS)
 
 # ROOT_LIBRARY = libAra.${DLLSUF}

--- a/StandardDefinitions.mk
+++ b/StandardDefinitions.mk
@@ -34,7 +34,7 @@ ifdef ARA_UTIL_INSTALL_DIR
 	ARA_UTIL_INC_DIR=${ARA_UTIL_INSTALL_DIR}/include
 	CXXFLAGS += -DARA_UTIL_EXISTS
 	DICT_FLAGS = -DARA_UTIL_EXISTS
-	LD_ARA_UTIL=-L${ARA_UTIL_LIB_DIR} -lAraEvent -lsqlite3
+	LD_ARA_UTIL=-L${ARA_UTIL_LIB_DIR} -lAraEvent
 	INC_ARA_UTIL=-I${ARA_UTIL_INC_DIR}
 	ARA_ROOT_HEADERS=RawIcrrStationHeader.h RawIcrrStationEvent.h  RawAraStationEvent.h  FullIcrrHkEvent.h  AraEventCalibrator.h IcrrTriggerMonitor.h IcrrHkData.h AraRawIcrrRFChannel.h AraAntennaInfo.h AraGeomTool.h  UsefulAraStationEvent.h UsefulIcrrStationEvent.h araIcrrStructures.h AtriEventHkData.h AtriSensorHkData.h araAtriStructures.h araSoft.h araIcrrDefines.h RawAtriSimpleStationEvent.h RawAtriStationBlock.h RawAraGenericHeader.h RawAtriStationEvent.h UsefulAtriStationEvent.h  AraStationInfo.h 
 #AraFileUtility.h araSimDefines.h araSimStructures.h


### PR DESCRIPTION
…nd StandardDefinitions.mk. No include path for the sqlite headers is specified either, thus no need to link to the library.