### PR TITLE
Parameter compatibility issue #7

### DIFF
--- a/AraSim.cc
+++ b/AraSim.cc
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {   // read setup.txt file
     settings1->ReadFile(setupfile);
     cout<<"Read "<<setupfile<<" file!"<<endl;
 
-    int settings_compatibility_error = settings1->CheckCompatibilities();
+    int settings_compatibility_error = settings1->CheckCompatibilitiesSettings();
     if (settings_compatibility_error > 0) {
         cerr<<"There are "<< settings_compatibility_error<<" errors from settings. Check error messages."<<endl;
         return -1;
@@ -351,7 +351,7 @@ int main(int argc, char **argv) {   // read setup.txt file
                 
     // check if settings have to compatibility problems
     // if there's any, stop AraSim
-    settings_compatibility_error = settings1->CheckCompatibilities(detector);
+    settings_compatibility_error = settings1->CheckCompatibilitiesDetector(detector);
     if (settings_compatibility_error > 0) {
         cerr<<"There are "<< settings_compatibility_error<<" errors from settings after Detector class instance is initialized. Check error messages."<<endl;
         return -1;

--- a/AraSim.cc
+++ b/AraSim.cc
@@ -83,6 +83,12 @@ int main(int argc, char **argv) {   // read setup.txt file
     settings1->ReadFile(setupfile);
     cout<<"Read "<<setupfile<<" file!"<<endl;
 
+    int settings_compatibility_error = settings1->CheckCompatibilities();
+    if (settings_compatibility_error > 0) {
+        cerr<<"There are "<< settings_compatibility_error<<" errors from settings. Check error messages."<<endl;
+        return -1;
+    }
+ 
     cout<<"\n\tNew values!"<<endl;
     cout<<"NNU : "<<settings1->NNU<<endl;
     cout<<"ICE_MODEL : "<<settings1->ICE_MODEL<<endl;
@@ -345,9 +351,9 @@ int main(int argc, char **argv) {   // read setup.txt file
                 
     // check if settings have to compatibility problems
     // if there's any, stop AraSim
-    int settings_compatibility_error = settings1->CheckCompatibilities(detector);
+    settings_compatibility_error = settings1->CheckCompatibilities(detector);
     if (settings_compatibility_error > 0) {
-        cerr<<"There are "<< settings_compatibility_error<<" errors from settings. Check error messages."<<endl;
+        cerr<<"There are "<< settings_compatibility_error<<" errors from settings after Detector class instance is initialized. Check error messages."<<endl;
         return -1;
     }
         

--- a/Settings.cc
+++ b/Settings.cc
@@ -785,6 +785,14 @@ int Settings::CheckCompatibilities(Detector *detector) {
         }
     }
 
+    return num_err;
+}
+
+int Settings::CheckCompatibilities() {
+
+    int num_err = 0;
+
+
     /*
     // if INTERACTION_MODE is 0 (sphere area and obtain Aeff), make sure using GETCHORD_MODE=1
     if (INTERACTION_MODE==0) { // picknear_sphere mode
@@ -948,6 +956,12 @@ int Settings::CheckCompatibilities(Detector *detector) {
 		
       }
     }
+
+   //Check that DETECTOR_STATION=0 is only used with DETECTOR=3
+   if (DETECTOR_STATION==0 && DETECTOR!=3){
+      cerr << " DETECTOR_STATION=0 doesn't work with DETECTOR!=3. If you want to work with TestBed, use DETECTOR=3 & DETECTOR_STATION=0" << endl;
+      num_err++;
+   }
 
 
     return num_err;

--- a/Settings.cc
+++ b/Settings.cc
@@ -734,7 +734,7 @@ void Settings::ReadEvtFile(string evtfile){
     return;
 }
 
-int Settings::CheckCompatibilities(Detector *detector) {
+int Settings::CheckCompatibilitiesDetector(Detector *detector) {
 
     int num_err = 0;
 
@@ -788,7 +788,7 @@ int Settings::CheckCompatibilities(Detector *detector) {
     return num_err;
 }
 
-int Settings::CheckCompatibilities() {
+int Settings::CheckCompatibilitiesSettings() {
 
     int num_err = 0;
 

--- a/Settings.h
+++ b/Settings.h
@@ -22,8 +22,8 @@ class Settings
         void ReadFile(string setupfile);
         void ReadEvtFile(string evtfile);
 
-        int CheckCompatibilities();// check if settings are not compatible to each other
-        int CheckCompatibilities(Detector *detector);// check if settings are not compatible to each other. checking against initialized Detector *detector object
+        int CheckCompatibilitiesSettings();// check if settings are not compatible to each other
+        int CheckCompatibilitiesDetector(Detector *detector);// check if settings are not compatible to each other. checking against initialized Detector *detector object
 
 	int ARASIM_VERSION_MAJOR;
         int ARASIM_VERSION_MINOR;

--- a/Settings.h
+++ b/Settings.h
@@ -22,8 +22,8 @@ class Settings
         void ReadFile(string setupfile);
         void ReadEvtFile(string evtfile);
 
-
-        int CheckCompatibilities(Detector *detector);// check if settings are not compatible to each other
+        int CheckCompatibilities();// check if settings are not compatible to each other
+        int CheckCompatibilities(Detector *detector);// check if settings are not compatible to each other. checking against initialized Detector *detector object
 
 	int ARASIM_VERSION_MAJOR;
         int ARASIM_VERSION_MINOR;

--- a/log.txt
+++ b/log.txt
@@ -1502,3 +1502,12 @@ which are not used anywhere else in AraSim currently
 
 
 Also clean-up tabs in Vector class
+
+2019/12/21 Ming-Yuan Lu
+
+Implement a check that requires DETECTOR_STATION=0 to be used with DETECTOR=3
+
+Split Settings::CheckCompatibilities function to two - one that does not require a instantiated Detector object, and one that does. 
+The former is moved to be called right after the setup file is read, which spares having to instantiate all class objects before 
+we even check parameter compatibility. The latter is left as is.
+

--- a/log.txt
+++ b/log.txt
@@ -1511,3 +1511,6 @@ Split Settings::CheckCompatibilities function to two - one that does not require
 The former is moved to be called right after the setup file is read, which spares having to instantiate all class objects before 
 we even check parameter compatibility. The latter is left as is.
 
+2020/01/15 Ming-Yuan Lu
+Rename overloaded Settings::CheckCompatibilities functions to Settings::CheckCompatibilitiesSettings() & Settings::CheckCompatibilitiesDetector(Detector *detector) to avoid confusion.
+


### PR DESCRIPTION
This pull request addresses the issue that AraSim throws a memory error when using `DETECTOR=4` and `DETECTOR_STATION=0`. See issue #7 . 

To solve this, two changes were made:

1. This is essentially a parameter compatibility issue. `DETECTOR_STATION=0` (TestBed) should only be used with `DETECTOR=3`, and no other `DETECTOR` modes. Such check is implemented in the `Settings::CheckCompatibilities` function.

2. The `Settings::CheckCompatibilities` function is called after several class objects are instantiated, eg `Trigger`, `Event`, `Detector` etc. This is probably because the function was implemented to take a `Detector` object as its argument. However, this call placement is illogical, since if there are incompatible parameters, the user should be noticed right after the setup file is read, and the program should stop immediately. As it's implemented, the memory error is thrown in the Detector object instantiation, which comes _before_ the checks. So here I split the `Settings::CheckCompatibilities` function into two functions - one that does not require a `Detector` object (check in point 1 goes here), and one that does. The former is repositioned to be called immediately after the setup files is read. The latter, due to its argument requirement, stays in the same place.

Combing the two changes, the issue is solved. This also safeguards future issues arising from the same code structure problem.  