### PR TITLE
Add freq dep att length

### DIFF
--- a/IceModel.cc
+++ b/IceModel.cc
@@ -265,6 +265,62 @@ double IceModel::GetARAIceAttenuLength(double depth) {
 }
 
 
+//! Get the ice temperature as a function of depth
+/*!
+    Function returns the ice temperaturea as a function of depth (a positive number)
+    This equation is a result of the fit from the Berkeley group
+    which used IceCube data to probe the temperature as a function of depth
+    And is described here: https://icecube.wisc.edu/~araproject/radio/#figure1a
+    and https://icecube.wisc.edu/~araproject/radio/temp/
+
+    \param z depth as a positive number in meters
+    \return ice temperature in Celsius
+*/
+double IceModel::temperature(double z){
+  if( depth < 0.){
+    cerr<<"depth negative! "<<depth<<endl;
+  }
+  double temp = (-51.0696) + (0.00267687 * z) + (-1.59061E-08 * pow(z,2.)) + (1.83415E-09 * pow(z,3.));
+  return temp;
+}
+
+//! Get the ice attenuation length at a depth and frequency
+/*!
+    Function returns the ice attenuation length at a given depth (in m)
+    and frequency (in GHz). This uses a fit from Besson et al.
+    described here: https://icecube.wisc.edu/~araproject/radio/atten/
+
+    \param depth depth as a positive number in meters
+    \param freq frequency as a number in GHz
+    \return ice temperature in Celsius
+*/
+double IceModel::GetFreqDepIceAttenuLength(double depth, double freq) {
+  double AttenL = 0.0;
+  if ( depth < 0. ) {
+    cerr<<"depth negative! "<<depth<<endl;
+  }
+  else {
+    double t = temperature(depth);
+    const double f0=0.0001, f2=3.16;
+    const double w0=log(f0), w1=0.0, w2=log(f2), w=log(freq);
+    const double b0=-6.74890+t*(0.026709-t*0.000884);
+    const double b1=-6.22121-t*(0.070927+t*0.001773);
+    const double b2=-4.09468-t*(0.002213+t*0.000332);
+    double a,bb;
+    if(freq<1.){
+      a=(b1*w0-b0*w1)/(w0-w1);
+      bb=(b1-b0)/(w1-w0);
+    }
+    else{
+      a=(b2*w1-b1*w2)/(w1-w2);
+      bb=(b2-b1)/(w2-w1);
+    }
+    AttenL = 1./exp(a+bb*w);
+  }
+  return AttenL;
+}
+
+
 
 
 int IceModel::Getice_model() {

--- a/IceModel.cc
+++ b/IceModel.cc
@@ -277,8 +277,8 @@ double IceModel::GetARAIceAttenuLength(double depth) {
     \return ice temperature in Celsius
 */
 double IceModel::temperature(double z){
-  if( depth < 0.){
-    cerr<<"depth negative! "<<depth<<endl;
+  if( z < 0.){
+    cerr<<"depth negative! "<<z<<endl;
   }
   double temp = (-51.0696) + (0.00267687 * z) + (-1.59061E-08 * pow(z,2.)) + (1.83415E-09 * pow(z,3.));
   return temp;

--- a/IceModel.h
+++ b/IceModel.h
@@ -183,6 +183,8 @@ void GetFresnel (
   int ARA_IceAtten_bin;
 
   double GetARAIceAttenuLength(double depth);
+  double GetFreqDepIceAttenuLength(double depth, double freq);
+  double temperature(double z);
 
   //  void FillArraysforTree(double lon_ground[1068][869],double lat_ground[1068][869],double lon_ice[1200][1000],double lat_ice[1200][1000],double lon_water[1200][1000],double lat_water[1200][1000]);
 

--- a/Report.cc
+++ b/Report.cc
@@ -600,7 +600,7 @@ void Report::Connect_Interaction_Detector (Event *event, Detector *detector, Ray
 
                                           // multiply all factors for traveling ice
                                           //vmmhz1m_tmp = vmmhz1m_tmp / ray_output[0][ray_sol_cnt] * exp(-ray_output[0][ray_sol_cnt]/icemodel->EffectiveAttenuationLength(settings1, event->Nu_Interaction[0].posnu, 0)) * mag * fresnel;  // assume whichray = 0, now vmmhz1m_tmp has all factors except for the detector properties (antenna gain, etc)
-                                          if (settings1->USE_ARA_ICEATTENU==1 || settings->USE_ARA_ICEATTENU==0){
+                                          if (settings1->USE_ARA_ICEATTENU==1 || settings1->USE_ARA_ICEATTENU==0){
                                             vmmhz1m_tmp = vmmhz1m_tmp / ray_output[0][ray_sol_cnt] * IceAttenFactor * mag * fresnel;  // assume whichray = 0, now vmmhz1m_tmp has all factors except for the detector properties (antenna gain, etc)
                                           }
                                           else if (settings1->USE_ARA_ICEATTENU==2){

--- a/Settings.h
+++ b/Settings.h
@@ -43,7 +43,7 @@ class Settings
         int CONSTANTICETHICKNESS; // set ice thickness to constant value
         int FIXEDELEVATION; // fix the elevation to the thickness of ice.
         int MOOREBAY; //1=use Moore's Bay measured ice field attenuation length for the west land, otherwise use South Pole data
-        int USE_ARA_ICEATTENU; // 0 : use old ice attenuation factor with one depth info, 1 : (default) use ARA measured ice attenuation factor with depth from ray steps
+        int USE_ARA_ICEATTENU; // 0 : use old ice attenuation factor with one depth info, 1 : (default) use ARA measured ice attenuation factor with depth from ray steps, 2: use frequency dependent model with depth from ray steps
 
 	int Z_THIS_TOLERANCE; // 0 : (default) use default 'requiredAccuracy' parameter for ray tracing, 1 : change 'requiredAccuracy' parameter by Z_TOLERANCE
 	

--- a/log.txt
+++ b/log.txt
@@ -1526,3 +1526,12 @@ Related documents in DocBD
 Part1:http://ara.physics.wisc.edu/docs/0021/002152/001/20200622_Arrival_Time_Delay_in_AraSim.pdf
 Part2:http://ara.physics.wisc.edu/docs/0021/002158/001/20200706_Arrival_Time_Delay_in_AraSim_part2.pdf
 Part3:http://ara.physics.wisc.edu/docs/0021/002161/001/20200713_Arrival_Time_Delay_in_AraSim_part3.pdf
+
+2020/10/22 Brian Clark
+Add an additional ice attenuation mode (settings1->USE_ARA_ICEATTENU == 2) which 
+will use the frequency dependent icemodel from Besson et al described here: https://icecube.wisc.edu/~araproject/radio/atten/.
+This required changes to Report and IceModel. In particulart two new functions IceModel:
+1. GetFreqDepIceAttenuLength
+2. temperature
+Also, change the attenuation calculation so that it computes the attenuation using the midpoint of the ray
+instead of the end of the ray, which gives a more accurate calculation for the attenuation length.


### PR DESCRIPTION
This pull request does two things.

1. Adds the frequency dependent attenuation length model back into the master branch (finally). Replaces the `FreqDepAttenLength` branch.
2. Adds the calculation of the attenuation at the midpoint of the ray instead of the end. Replaces the `AttenLengthMidPoint` branch.

This pull request supersedes #19.