### PR TITLE
Elegantly handle neutrinos with energies outside of cross-section validity range

### DIFF
--- a/AraSim.cc
+++ b/AraSim.cc
@@ -398,6 +398,19 @@ int main(int argc, char **argv) {   // read setup.txt file
 
         // event = new Event ( settings1, spectra, primary1, icemodel, detector, signal, sec1 );
         event = new Event ( settings1, spectra, primary1, icemodel, detector, signal, sec1, Events_Thrown );
+        if(event->Nu_Interaction.size()<1){
+            // If for some reason no interactions were placed into the event holder, continue.
+            // This should be exceedingly rare, but could happen if something
+            // goes wrong with interaction generation.
+            // BAC added this specifically because if the neutrino is generated
+            // with a higher energy than is available in the sigma parameterization
+            // then no interaction will be added and Nu_Interaction will be empty.
+            // But also, it's bad practice to assume the size of a vector anyway
+            // so this is just better generically.
+            cout<<"Warning! The interaction vector is empty!"<<endl;
+            cout<<"Continuing on to the next event."<<endl;
+            continue;
+        }
         event->inu_passed = -1;
                 
         report = new Report(detector, settings1);

--- a/Event.cc
+++ b/Event.cc
@@ -98,11 +98,19 @@ Event::Event (Settings *settings1, Spectra *spectra1, Primaries *primary1, IceMo
 
         Nu_temp = new Interaction (pnu, nuflavor, nu_nubar, n_interactions, icemodel, detector, settings1, primary1, signal, sec1 );
         //report_tmp = new Report(detector ,settings1);
-        
-        Nu_Interaction.push_back(*Nu_temp);  // for the first interaction
-        //test_report.push_back(*report_tmp);
-
-        delete Nu_temp;
+        if(Nu_temp->sigma_err==1){
+            // only if getting sigma was successful
+            Nu_Interaction.push_back(*Nu_temp);  // for the first interaction
+            delete Nu_temp;
+        }
+        else{
+            //otherwise, just delete Nu_temp, but don't put it into Nu_Interaction
+            delete Nu_temp;
+            // and warn!
+            cout<<"Warning! sigma_err is "<<Nu_temp->sigma_err<<endl;
+            cout<<"This means the cross section was not found correctly!"<<endl;
+            cout<<"Nu_Interaction will be empty!"<<endl;
+        }
 
         // for multiple interactions...
         /*

--- a/Primaries.cc
+++ b/Primaries.cc
@@ -351,8 +351,8 @@ int Primaries::GetSigma(double pnu,double& sigma,double &len_int_kgm2,Settings *
   // calculate cross section
   if (pnu<mine[settings1->SIGMAPARAM] || pnu>maxe[settings1->SIGMAPARAM]) {
     cout <<  "Need a parameterization for this energy region.(new)\n";
-//    return 0;
-      return 1;
+    return 0;
+      // return 1;
   } //if
   else {
    
@@ -1141,6 +1141,12 @@ Interaction::Interaction (double pnu, string nuflavor, int nu_nubar, int &n_inte
 
     //sigma_err = primary1->GetSigma( pnu, sigma, len_int_kgm2, settings1, nu_nubar, currentint);
     sigma_err = primary1->GetSigma( pnu, sigma, len_int_kgm2, settings1, nu_nubar, currentint, len_int_kgm2_total );
+    if(sigma_err!=1){
+        // getting the cross section has not worked
+        // likely we are asking for an energy for which it does not have a parameterization
+        // so we return immediately
+        return;
+    }
 //--------------------------------------------------
 //     cout<<"len_int_kgm2 from GetSigma : "<<len_int_kgm2<<endl;
 //     cout<<"sigma from GetSigma : "<<sigma<<endl;

--- a/Primaries.h
+++ b/Primaries.h
@@ -327,7 +327,7 @@ Interaction (IceModel *antarctica, Detector *detector, Settings *settings1, Prim
   double chord;  // chord in m from earth entrance to rock-ice boundary
   double logchord; // log_10 of chord length earth entrance to where it enters ice
   double weight_bestcase; // what weight1 would be if whole earth had density of crust - for quick and dirty calculation of best case scenario
-  int sigma_err;    // 0 if energy too low for the parameterization from GetSigma, otherwise 1
+  int sigma_err;    // 0 if GetSigma is un-successful (!), otherwise 1
   double sigma;
 
   // input information for Getchord

--- a/log.txt
+++ b/log.txt
@@ -1549,3 +1549,12 @@ bundled them into a single ReadAllAntennaGains function. This make it much more 
 For better organization, I also moved all of the antenna gain files into a new data/antennas folder.
 
 Finally, I introduced, through ANTENNA_MODE=3, the Chiba XFDTD antenna models.
+
+============================================================================
+2020/11/04 Brian Clark
+
+Make a change to address an issue (see https://github.com/ara-software/AraSim/issues/28)
+where if a neutrino energy is drawn above the range where the cross-section parameterization
+is defined, the simulation just freezes. Now, the Event class will return
+an event without an interactions, and AraSim will not proceed in the absence of an interaction.
+Very verbose as well, which should hopefully reduce confusion.


### PR DESCRIPTION
This pull request addresses #28. This is an issue where if a neutrino energy is drawn above the range where the cross-section parameterization is defined, the simulation just freezes. Now, the Event class will return an event without an interactions, and AraSim will not proceed in the absence of an interaction. Very verbose as well, which should hopefully reduce confusion.