### PR TITLE
New pol factor calculation

### DIFF
--- a/IceModel.cc
+++ b/IceModel.cc
@@ -1822,6 +1822,23 @@ void IceModel::GetFresnel (
         mag = sqrt( abs(tan (launch_angle)) / abs(tan (rec_angle)) );
     }
 
+    /*
+      * BAC, AC, JT on 2020/11/3
+      * The following calculation is a bit tricky. As best we can tell, here is the logic.
+      * 
+      * perp is tangent to the surface (because posnu is perp to the earth surface)
+      * src_parallel is then parallel to the surface at the vertex/source
+      * trg_parallel is then parallel to the surfaace at the target/receiver
+      *
+      * pol_parallel_src is the component of vector that's parallel to the surface at the vertex/source
+      * pol_perp_src is the component of the vector that's perpendicular to the surface at the vertex
+      * 
+      * But, pol_parallel_trg = pol_parallel_src and pol_perp_trg = pol_perp_src
+      * So we are unsure if the polarization is following the ray bending.
+      * Then again, Pol involves trg_parallel, which involves the receive vector.
+      * So it's not clear cut.
+     */
+
     Vector perp = launch_vector.Cross( posnu ).Unit();    // perp unit vector it should be same in both src and trg
     Vector src_parallel = perp.Cross( launch_vector ).Unit();
     Vector trg_parallel = perp.Cross( rec_vector ).Unit();

--- a/Report.cc
+++ b/Report.cc
@@ -4042,18 +4042,23 @@ double Report::GaintoHeight(double gain, double freq, double n_medium) {
     return 2*sqrt(gain/4/PI*CLIGHT*CLIGHT/(freq*freq*n_medium*n_medium)*Zr/(Z0/n_medium));  // n_medium parts are changed from icemc(I believe this is correct one; E. Hong)
 }
 
+double Report::calculatePolFactor(Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type){
+     double pol_factor=0.;
+     if (ant_type == 0) {    // if v pol
+         pol_factor = n_trg_pokey * Pol_vector;
+     }
+     else if (ant_type == 1) {   // if h pol
+         pol_factor = n_trg_slappy * Pol_vector;
+     }
+     pol_factor = abs(pol_factor);
+     return pol_factor;
+ }
+
 
 void Report::ApplyAntFactors(double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vmmhz) {  // vmmhz is input and output. output will have some antenna factors on it
 
     //double pol_factor;
-
-    if (ant_type == 0) {    // if v pol
-        pol_factor = n_trg_pokey * Pol_vector;
-    }
-    else if (ant_type == 1) {   // if h pol
-        pol_factor = n_trg_slappy * Pol_vector;
-    }
-    pol_factor = abs(pol_factor);
+    pol_factor = calculatePolFactor(n_trg_pokey, n_trg_slappy, Pol_vector, ant_type);
 
     // apply 3dB spliter, d nu to prepare FFT
     // now actually vmmhz is not V/m/MHz but V/m/Hz unit
@@ -4073,19 +4078,8 @@ void Report::ApplyAntFactors(double heff, Vector &n_trg_pokey, Vector &n_trg_sla
 
 void Report::ApplyAntFactors_Tdomain (double AntPhase, double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_real, double &vm_img, Settings *settings1) {  // vm is input and output. output will have some antenna factors on it
 
-
-
     //double pol_factor;
-
-    if (ant_type == 0) {    // if v pol
-        pol_factor = n_trg_pokey * Pol_vector;
-    }
-    else if (ant_type == 1) {   // if h pol
-        pol_factor = n_trg_slappy * Pol_vector;
-    }
-    pol_factor = abs(pol_factor);
-
-
+    pol_factor = calculatePolFactor(n_trg_pokey, n_trg_slappy, Pol_vector, ant_type);
 
     if ( settings1->PHASE_SKIP_MODE != 1 ) {
 
@@ -4138,19 +4132,8 @@ void Report::ApplyAntFactors_Tdomain (double AntPhase, double heff, Vector &n_tr
 
 void Report::ApplyAntFactors_Tdomain_Transmitter (double AntPhase, double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_real, double &vm_img, Settings *settings1) {  // vm is input and output. output will have some antenna factors on it
 
-
-
     //double pol_factor;
-
-    if (ant_type == 0) {    // if v pol
-        pol_factor = n_trg_pokey * Pol_vector;
-    }
-    else if (ant_type == 1) {   // if h pol
-        pol_factor = n_trg_slappy * Pol_vector;
-    }
-    pol_factor = abs(pol_factor);
-
-
+    pol_factor = calculatePolFactor(n_trg_pokey, n_trg_slappy, Pol_vector, ant_type);
 
     if ( settings1->PHASE_SKIP_MODE != 1 ) {
 

--- a/Report.cc
+++ b/Report.cc
@@ -4060,7 +4060,7 @@ double Report::GaintoHeight(double gain, double freq, double n_medium) {
     return 2*sqrt(gain/4/PI*CLIGHT*CLIGHT/(freq*freq*n_medium*n_medium)*Zr/(Z0/n_medium));  // n_medium parts are changed from icemc(I believe this is correct one; E. Hong)
 }
 
-double Report::calculatePolFactor(Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double antenna_theta, double antenna_phi){
+double Report::calculatePolFactor(Vector &Pol_vector, int ant_type, double antenna_theta, double antenna_phi){
     // convert to radians
      antenna_phi*=(PI/180);
      antenna_theta*=(PI/180);
@@ -4088,7 +4088,7 @@ double Report::calculatePolFactor(Vector &n_trg_pokey, Vector &n_trg_slappy, Vec
 void Report::ApplyAntFactors(double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vmmhz, double antenna_theta, double antenna_phi) {  // vmmhz is input and output. output will have some antenna factors on it
 
     //double pol_factor;
-    pol_factor = calculatePolFactor(n_trg_pokey, n_trg_slappy, Pol_vector, ant_type, antenna_theta, antenna_phi);
+    pol_factor = calculatePolFactor(Pol_vector, ant_type, antenna_theta, antenna_phi);
 
     // apply 3dB spliter, d nu to prepare FFT
     // now actually vmmhz is not V/m/MHz but V/m/Hz unit
@@ -4119,7 +4119,7 @@ void Report::ApplyAntFactors_Tdomain (double AntPhase, double heff, Vector &n_tr
      if(useInTransmitterMode==true){ sign=-1.;};
 
     //double pol_factor;
-    pol_factor = calculatePolFactor(n_trg_pokey, n_trg_slappy, Pol_vector, ant_type, antenna_theta, antenna_phi);
+    pol_factor = calculatePolFactor(Pol_vector, ant_type, antenna_theta, antenna_phi);
     if ( settings1->PHASE_SKIP_MODE != 1 ) {
         double phase_current;
         if ( vm_real != 0. ) {
@@ -4157,7 +4157,7 @@ void Report::ApplyAntFactors_Tdomain (double AntPhase, double heff, Vector &n_tr
 void Report::ApplyAntFactors_Tdomain_FirstTwo (double heff, double heff_lastbin, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_bin0, double &vm_bin1, double antenna_theta, double antenna_phi) {  // vm is input and output. output will have some antenna factors on it
 
     //double pol_factor;
-    pol_factor = calculatePolFactor(n_trg_pokey, n_trg_slappy, Pol_vector, ant_type, antenna_theta, antenna_phi);
+    pol_factor = calculatePolFactor(Pol_vector, ant_type, antenna_theta, antenna_phi);
 
     vm_bin0 = vm_bin0 / sqrt(2.) * 0.5 * heff * pol_factor; // sqrt(2) for 3dB splitter for TURF, SURF, 0.5 to calculate power with heff
     vm_bin1 = vm_bin1 / sqrt(2.) * 0.5 * heff_lastbin * pol_factor; // sqrt(2) for 3dB splitter for TURF, SURF, 0.5 to calculate power with heff

--- a/Report.cc
+++ b/Report.cc
@@ -685,7 +685,7 @@ void Report::Connect_Interaction_Detector (Event *event, Detector *detector, Ray
                                                Pol_vector = n_trg_slappy + n_trg_pokey;
                                            }
                                            
-                                           ApplyAntFactors(heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, vmmhz1m_tmp);
+                                           ApplyAntFactors(heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, vmmhz1m_tmp, antenna_theta, antenna_phi);
 
 					   //cout << "Check 2" << endl;
                                            //stations[i].strings[j].antennas[k].VHz_antfactor[ray_sol_cnt].push_back( vmmhz1m_tmp );
@@ -992,18 +992,18 @@ void Report::Connect_Interaction_Detector (Event *event, Detector *detector, Ray
                                                        if ( settings1->ALL_ANT_V_ON==0 ) {
                                                        
                                                            ApplyAntFactors_Tdomain( detector->GetAntPhase_1D( freq_tmp*1.e-6, antenna_theta, antenna_phi, detector->stations[i].strings[j].antennas[k].type ),
-                                                               heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1 );
+                                                               heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1, antenna_theta, antenna_phi );
                                                        }
                                                        else if ( settings1->ALL_ANT_V_ON==1 ) {
                                                            ApplyAntFactors_Tdomain( detector->GetAntPhase_1D( freq_tmp*1.e-6, antenna_theta, antenna_phi, 0 ),
-                                                               heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1 );
+                                                               heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1, antenna_theta, antenna_phi );
                                                        }
 
 
 
                                                    }
                                                    else {
-                                                       ApplyAntFactors_Tdomain_FirstTwo( heff, heff_lastbin, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1] );
+                                                       ApplyAntFactors_Tdomain_FirstTwo( heff, heff_lastbin, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], antenna_theta, antenna_phi );
                                                    }
 
 
@@ -1296,18 +1296,18 @@ void Report::Connect_Interaction_Detector (Event *event, Detector *detector, Ray
 					     if ( settings1->ALL_ANT_V_ON==0 ) {
 					       
 					       ApplyAntFactors_Tdomain( detector->GetAntPhase_1D( freq_tmp*1.e-6, antenna_theta, antenna_phi, detector->stations[i].strings[j].antennas[k].type ),
-									heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1 );
+									heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1, antenna_theta, antenna_phi );
 					     }
 					     else if ( settings1->ALL_ANT_V_ON==1 ) {
 					       ApplyAntFactors_Tdomain( detector->GetAntPhase_1D( freq_tmp*1.e-6, antenna_theta, antenna_phi, 0 ),
-									heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1 );
+									heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1, antenna_theta, antenna_phi );
 					     }
 					     
 					     
 					     
 					   }
 					   else {
-					     ApplyAntFactors_Tdomain_FirstTwo( heff, heff_lastbin, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1] );
+					     ApplyAntFactors_Tdomain_FirstTwo( heff, heff_lastbin, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], antenna_theta, antenna_phi );
 					   }
 					   
 					   //
@@ -1576,19 +1576,19 @@ void Report::Connect_Interaction_Detector (Event *event, Detector *detector, Ray
 					     if ( settings1->ALL_ANT_V_ON==0 ) {
 					       // modified 2020/11/16 by BAC with the final "true" argument to use the ApplyAntFactors_Tdomain function
 					       ApplyAntFactors_Tdomain( detector->GetAntPhase_1D( freq_tmp*1.e-6, ant_theta_trans, antenna_phi, detector->stations[i].strings[j].antennas[k].type ),
-										    heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1, true);
+										    heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1, true, antenna_theta, antenna_phi);
 					     }
 					     else if ( settings1->ALL_ANT_V_ON==1 ) {
                            // modified 2020/11/16 by BAC with the final "true" argument to use the ApplyAntFactors_Tdomain function
 					       ApplyAntFactors_Tdomain( detector->GetAntPhase_1D( freq_tmp*1.e-6, ant_theta_trans, antenna_phi, 0 ),
-										    heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1, true );
+										    heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1, true, antenna_theta, antenna_phi );
 					     }
 					     
 					     
 					     
 					   }
 					   else {
-					     ApplyAntFactors_Tdomain_FirstTwo( heff, heff_lastbin_trans, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1] );
+					     ApplyAntFactors_Tdomain_FirstTwo( heff, heff_lastbin_trans, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], antenna_theta, antenna_phi );
 					   }
 					   
 					   //
@@ -1634,18 +1634,18 @@ void Report::Connect_Interaction_Detector (Event *event, Detector *detector, Ray
 					     if ( settings1->ALL_ANT_V_ON==0 ) {
 					       
 					       ApplyAntFactors_Tdomain( detector->GetAntPhase_1D( freq_tmp*1.e-6, antenna_theta, antenna_phi, detector->stations[i].strings[j].antennas[k].type ),
-									heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1 );
+									heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1, antenna_theta, antenna_phi );
 					     }
 					     else if ( settings1->ALL_ANT_V_ON==1 ) {
 					       ApplyAntFactors_Tdomain( detector->GetAntPhase_1D( freq_tmp*1.e-6, antenna_theta, antenna_phi, 0 ),
-									heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1 );
+									heff, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], settings1, antenna_theta, antenna_phi );
 					     }
 					     
 					     
 					     
 					   }
 					   else {
-					     ApplyAntFactors_Tdomain_FirstTwo( heff, heff_lastbin, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1] );
+					     ApplyAntFactors_Tdomain_FirstTwo( heff, heff_lastbin, n_trg_pokey, n_trg_slappy, Pol_vector, detector->stations[i].strings[j].antennas[k].type, Pol_factor, V_forfft[2*n], V_forfft[2*n+1], antenna_theta, antenna_phi );
 					   }
 					   
 					   //
@@ -4060,23 +4060,35 @@ double Report::GaintoHeight(double gain, double freq, double n_medium) {
     return 2*sqrt(gain/4/PI*CLIGHT*CLIGHT/(freq*freq*n_medium*n_medium)*Zr/(Z0/n_medium));  // n_medium parts are changed from icemc(I believe this is correct one; E. Hong)
 }
 
-double Report::calculatePolFactor(Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type){
+double Report::calculatePolFactor(Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double antenna_theta, double antenna_phi){
+    // convert to radians
+     antenna_phi*=(PI/180);
+     antenna_theta*=(PI/180);
+
+     // calculate the local thetaHat and phiHat vectors
+     Vector thetaHat = Vector(cos(antenna_theta)*cos(antenna_phi),
+                              cos(antenna_theta)*sin(antenna_phi),
+                              -sin(antenna_theta));
+
+     Vector phiHat = Vector(-sin(antenna_phi),
+                            cos(antenna_phi),
+                            0);
      double pol_factor=0.;
      if (ant_type == 0) {    // if v pol
-         pol_factor = n_trg_pokey * Pol_vector;
+         pol_factor = Pol_vector *thetaHat;
      }
      else if (ant_type == 1) {   // if h pol
-         pol_factor = n_trg_slappy * Pol_vector;
+         pol_factor = Pol_vector *phiHat;
      }
      pol_factor = abs(pol_factor);
      return pol_factor;
  }
 
 
-void Report::ApplyAntFactors(double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vmmhz) {  // vmmhz is input and output. output will have some antenna factors on it
+void Report::ApplyAntFactors(double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vmmhz, double antenna_theta, double antenna_phi) {  // vmmhz is input and output. output will have some antenna factors on it
 
     //double pol_factor;
-    pol_factor = calculatePolFactor(n_trg_pokey, n_trg_slappy, Pol_vector, ant_type);
+    pol_factor = calculatePolFactor(n_trg_pokey, n_trg_slappy, Pol_vector, ant_type, antenna_theta, antenna_phi);
 
     // apply 3dB spliter, d nu to prepare FFT
     // now actually vmmhz is not V/m/MHz but V/m/Hz unit
@@ -4094,7 +4106,7 @@ void Report::ApplyAntFactors(double heff, Vector &n_trg_pokey, Vector &n_trg_sla
 
 
 
-void Report::ApplyAntFactors_Tdomain (double AntPhase, double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_real, double &vm_img, Settings *settings1, bool useInTransmitterMode) {  // vm is input and output. output will have some antenna factors on it
+void Report::ApplyAntFactors_Tdomain (double AntPhase, double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_real, double &vm_img, Settings *settings1, double antenna_theta, double antenna_phi, bool useInTransmitterMode) {  // vm is input and output. output will have some antenna factors on it
 
     // first, work out if we would like to use this function in "transmit" mode
      // which means that when we apply the phase shift, we need to subtract (!!)
@@ -4107,7 +4119,7 @@ void Report::ApplyAntFactors_Tdomain (double AntPhase, double heff, Vector &n_tr
      if(useInTransmitterMode==true){ sign=-1.;};
 
     //double pol_factor;
-    pol_factor = calculatePolFactor(n_trg_pokey, n_trg_slappy, Pol_vector, ant_type);
+    pol_factor = calculatePolFactor(n_trg_pokey, n_trg_slappy, Pol_vector, ant_type, antenna_theta, antenna_phi);
     if ( settings1->PHASE_SKIP_MODE != 1 ) {
         double phase_current;
         if ( vm_real != 0. ) {
@@ -4142,10 +4154,10 @@ void Report::ApplyAntFactors_Tdomain (double AntPhase, double heff, Vector &n_tr
 
 
 
-void Report::ApplyAntFactors_Tdomain_FirstTwo (double heff, double heff_lastbin, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_bin0, double &vm_bin1) {  // vm is input and output. output will have some antenna factors on it
+void Report::ApplyAntFactors_Tdomain_FirstTwo (double heff, double heff_lastbin, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_bin0, double &vm_bin1, double antenna_theta, double antenna_phi) {  // vm is input and output. output will have some antenna factors on it
 
     //double pol_factor;
-    pol_factor = calculatePolFactor(n_trg_pokey, n_trg_slappy, Pol_vector, ant_type);
+    pol_factor = calculatePolFactor(n_trg_pokey, n_trg_slappy, Pol_vector, ant_type, antenna_theta, antenna_phi);
 
     vm_bin0 = vm_bin0 / sqrt(2.) * 0.5 * heff * pol_factor; // sqrt(2) for 3dB splitter for TURF, SURF, 0.5 to calculate power with heff
     vm_bin1 = vm_bin1 / sqrt(2.) * 0.5 * heff_lastbin * pol_factor; // sqrt(2) for 3dB splitter for TURF, SURF, 0.5 to calculate power with heff

--- a/Report.h
+++ b/Report.h
@@ -265,6 +265,8 @@ class Report {
         void GetParameters (Position &src, Position &trg, Vector &nnu, double &viewangle, double receive_angle, Vector &launch_vector, Vector &receive_vector, Vector &n_trg_slappy, Vector &n_trg_pokey );    // get viewangle, launch, receive vectors  (it reads launch angle as a viewangle and returns actual viewangle)
 
         double GaintoHeight(double gain, double freq, double n_medium);
+        
+        double calculatePolFactor(Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type);
 
         void ApplyAntFactors(double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vmmhz);
 

--- a/Report.h
+++ b/Report.h
@@ -270,9 +270,7 @@ class Report {
 
         void ApplyAntFactors(double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vmmhz);
 
-        void ApplyAntFactors_Tdomain(double AntPhase, double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_real, double &vm_img, Settings *settings1);
-
-        void ApplyAntFactors_Tdomain_Transmitter(double AntPhase, double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_real, double &vm_img, Settings *settings1);
+        void ApplyAntFactors_Tdomain(double AntPhase, double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_real, double &vm_img, Settings *settings1, bool useInTransmitterMode=false);
 
         void ApplyAntFactors_Tdomain_FirstTwo ( double heff, double heff_lastbin, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_bin0, double &vm_bin1);
 

--- a/Report.h
+++ b/Report.h
@@ -266,7 +266,7 @@ class Report {
 
         double GaintoHeight(double gain, double freq, double n_medium);
         
-        double calculatePolFactor(Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double antenna_theta, double antenna_phi);
+        double calculatePolFactor(Vector &Pol_vector, int ant_type, double antenna_theta, double antenna_phi);
 
         void ApplyAntFactors(double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vmmhz, double antenna_theta, double antenna_phi);
 

--- a/Report.h
+++ b/Report.h
@@ -266,13 +266,13 @@ class Report {
 
         double GaintoHeight(double gain, double freq, double n_medium);
         
-        double calculatePolFactor(Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type);
+        double calculatePolFactor(Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double antenna_theta, double antenna_phi);
 
-        void ApplyAntFactors(double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vmmhz);
+        void ApplyAntFactors(double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vmmhz, double antenna_theta, double antenna_phi);
 
-        void ApplyAntFactors_Tdomain(double AntPhase, double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_real, double &vm_img, Settings *settings1, bool useInTransmitterMode=false);
+        void ApplyAntFactors_Tdomain(double AntPhase, double heff, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_real, double &vm_img, Settings *settings1, double antenna_theta, double antenna_phi, bool useInTransmitterMode=false);
 
-        void ApplyAntFactors_Tdomain_FirstTwo ( double heff, double heff_lastbin, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_bin0, double &vm_bin1);
+        void ApplyAntFactors_Tdomain_FirstTwo ( double heff, double heff_lastbin, Vector &n_trg_pokey, Vector &n_trg_slappy, Vector &Pol_vector, int ant_type, double &pol_factor, double &vm_bin0, double &vm_bin1, double antenna_theta, double antenna_phi);
 
 
         void ApplyElect_Tdomain(double freq, Detector *detector, double &vm_real, double &vm_img, Settings *settings1);

--- a/log.txt
+++ b/log.txt
@@ -1572,3 +1572,16 @@ I also updated the "read antenna" functions, and added a SWRtoTransCoeff helper
 function to convert between the now correct SWR values, and the transmission
 coefficients that are needed in order to do noise calculations.
 
+============================================================================
+ 2020/11/16 Brian Clark
+
+ This factorizes the calculation of the polarization factor into a calculatePolFactor function.
+ This removes a series of duplicated lines in the ApplyAntFactors* functions.
+
+ Also, this reduces the number of ApplyAntFactors_Tdomain functions. I have eliminated
+ the ApplyAntFactors_Tdomain_Transmitter function by instead passing a useInTransmitterMode
+ flag to the ApplyAntFactors_Tdomain function itself. This reduces the number of functions lying around.
+
+ Finally, it updates the way the polarization factor is calculated.
+ See this PR (https://github.com/ara-software/AraSim/issues/25)
+ and this talk from Ben Hokanson-Fasig (http://ara.physics.wisc.edu/cgi-bin/DocDB/ShowDocument?docid=1947).


### PR DESCRIPTION
 This factorizes the calculation of the polarization factor into a calculatePolFactor function.  This removes a series of duplicated lines in the ApplyAntFactors* functions.

 Also, this reduces the number of ApplyAntFactors_Tdomain functions. I have eliminated the ApplyAntFactors_Tdomain_Transmitter function by instead passing a useInTransmitterMode  flag to the ApplyAntFactors_Tdomain function itself. This reduces the number of functions lying around.

 Most importantly, it updates the way the polarization factor is calculated to use the theta and phi hat vectors.
 See this PR (https://github.com/ara-software/AraSim/issues/25) and this talk from Ben Hokanson-Fasig (http://ara.physics.wisc.edu/cgi-bin/DocDB/ShowDocument?docid=1947).