### PR TITLE
Add sinc interp

### DIFF
--- a/Report.cc
+++ b/Report.cc
@@ -1033,7 +1033,8 @@ void Report::Connect_Interaction_Detector (Event *event, Detector *detector, Ray
 
 
                                                // skip linear interpolation for now
-                                               Tools::SimpleLinearInterpolation_OutZero( stations[i].strings[j].antennas[k].Nnew[ray_sol_cnt], T_forfft, V_forfft, settings1->NFOUR/2, T_forint, volts_forint );
+                                               // changed to sinc interpolation Dec 2020 by BAC
+                                               Tools::SincInterpolation( stations[i].strings[j].antennas[k].Nnew[ray_sol_cnt], T_forfft, V_forfft, settings1->NFOUR/2, T_forint, volts_forint );
 
                                                // check what we save as V[], volts_forint? or volts_forfft
 
@@ -1336,7 +1337,8 @@ void Report::Connect_Interaction_Detector (Event *event, Detector *detector, Ray
 					 
 					 
 					 // skip linear interpolation for now
-					 Tools::SimpleLinearInterpolation_OutZero( stations[i].strings[j].antennas[k].Nnew[ray_sol_cnt], T_forfft, V_forfft, settings1->NFOUR/2, T_forint, volts_forint );
+					 // changed to sinc interpolation Dec 2020 by BAC
+					 Tools::SincInterpolation( stations[i].strings[j].antennas[k].Nnew[ray_sol_cnt], T_forfft, V_forfft, settings1->NFOUR/2, T_forint, volts_forint );
 					 
 					 // check what we save as V[], volts_forint? or volts_forfft
 					 
@@ -1674,7 +1676,8 @@ void Report::Connect_Interaction_Detector (Event *event, Detector *detector, Ray
 					 
 					 
 					 // skip linear interpolation for now
-					 Tools::SimpleLinearInterpolation_OutZero( stations[i].strings[j].antennas[k].Nnew[ray_sol_cnt], T_forfft, V_forfft, settings1->NFOUR/2, T_forint, volts_forint );
+					 // changed to sinc interpolation Dec 2020 by BAC
+					 Tools::SincInterpolation( stations[i].strings[j].antennas[k].Nnew[ray_sol_cnt], T_forfft, V_forfft, settings1->NFOUR/2, T_forint, volts_forint );
 					 
 					 // check what we save as V[], volts_forint? or volts_forfft
 					 

--- a/Tools.cc
+++ b/Tools.cc
@@ -548,7 +548,7 @@ void Tools::SincInterpolation(int n1, double *x1, double *y1, int n2, double *x2
     double first_input_sample = x1[0];
     double last_input_sample = x1[n1-1];
 
-    boost::math::interpolators::whittaker_shannon<double> interpolator(input_y.data(), t0, dT);
+    auto interpolator = boost::math::interpolators::whittaker_shannon<std::vector<double>>(std::move(input_y), t0, dT);
 
     for(int samp=0; samp<n2; samp++){
         if(x2[samp]<first_input_sample || x2[samp]>last_input_sample){
@@ -560,7 +560,7 @@ void Tools::SincInterpolation(int n1, double *x1, double *y1, int n2, double *x2
             printf("This is outside of the range of support for this function (%.2f - %.2f)\n",first_input_sample, last_input_sample);
             printf("Behavior may be unexpected! You have been warned...");
         }
-        y2[samp] = ws_interpolator(x2[samp]);
+        y2[samp] = interpolator(x2[samp]);
     }
 }
 

--- a/Tools.cc
+++ b/Tools.cc
@@ -535,6 +535,8 @@ void Tools::SincInterpolation(int n1, double *x1, double *y1, int n2, double *x2
     * See https://en.wikipedia.org/wiki/Whittaker–Shannon_interpolation_formula for information,
     * and https://www.boost.org/doc/libs/1_71_0/libs/math/doc/html/math_toolkit/whittaker_shannon.html
     * for implementation details from the boost documentation.
+    * This method is slower than linear or spline interpolation--so its use is probably 
+    * probably not ideal/necessary in cases where preserving spectral shape is not important.
     */
     
     // the whittaker-shannon method likes the data to be in a vector
@@ -558,7 +560,7 @@ void Tools::SincInterpolation(int n1, double *x1, double *y1, int n2, double *x2
             // and the results might be surprising...
             printf("WARNING! You have asked to evaluate the interpolation at (%.2f)\n",x2[samp]);
             printf("This is outside of the range of support for this function (%.2f - %.2f)\n",first_input_sample, last_input_sample);
-            printf("Behavior may be unexpected! You have been warned...");
+            printf("Behavior may be unexpected! You have been warned...\n");
         }
         y2[samp] = interpolator(x2[samp]);
     }

--- a/Tools.cc
+++ b/Tools.cc
@@ -553,22 +553,22 @@ void Tools::SincInterpolation(int n1, double *x1, double *y1, int n2, double *x2
     auto interpolator = boost::math::interpolators::whittaker_shannon<std::vector<double>>(std::move(input_y), t0, dT);
 
     for(int samp=0; samp<n2; samp++){
-    	// check if the sample comes before the first sample of the input array (x1[0])
+        // check if the sample comes before the first sample of the input array (x1[0])
         // or after the last sample of the input array (x1[n1-1])
         // if so, then we are asking for the function to *extrapolate*, not *interpolate*
         // just use the first/last sample, which replicates the behavior in SimpleLinearInterpolation_OutZero
         
         if(x2[samp]<first_input_sample){
-        	// before first sample, use first sample y1
-        	y2[samp] = y1[0];
+            // before first sample, use first sample y1
+            y2[samp] = y1[0];
         }
         else if(x2[samp]>last_input_sample){
-        	// after last sample, use last sample of y1
+            // after last sample, use last sample of y1
             y2[samp] = y1[n1-1];
         }
         else{
-        	// in the range of support, do interpolation
-        	y2[samp] = interpolator(x2[samp]);
+            // in the range of support, do interpolation
+            y2[samp] = interpolator(x2[samp]);
         }
     }
 }

--- a/Tools.cc
+++ b/Tools.cc
@@ -536,8 +536,8 @@ void Tools::SincInterpolation(int n1, double *x1, double *y1, int n2, double *x2
             // or after the last sample of the input array (x1[n1-1])
             // if so, then we are asking for the function to *extrapolate*, not *interpolate*
             // and the results might be surprising...
-            printf("WARNING! You have asked to evaluate the interpolation at (%.2f)\n");
-            printf("This is outside of the range of support for this function (%.2f - %.2f)\n");
+            printf("WARNING! You have asked to evaluate the interpolation at (%.2f)\n",x2[samp]);
+            printf("This is outside of the range of support for this function (%.2f - %.2f)\n",first_input_sample, last_input_sample);
             printf("Behavior may be unexpected! You have been warned...");
         }
         y2[samp] = ws_interpolator(x2[samp]);

--- a/Tools.cc
+++ b/Tools.cc
@@ -506,7 +506,7 @@ void Tools::NormalTimeOrdering_InvT(const int n,double *volts) {
 
 }
 
-//! A function to do since interpolation from time basis of x1 to the time basis of x2
+//! A function to do sinc interpolation from time basis of x1 to the time basis of x2
 /*!
     
     The function takes an input array (defined by n1, x1, y1), and interpolates

--- a/Tools.cc
+++ b/Tools.cc
@@ -521,7 +521,7 @@ void Tools::SincInterpolation(int n1, double *x1, double *y1, int n2, double *x2
     size_t num_input_samps = n1;
     std::vector<double> input_y(num_input_samps);
     for(size_t samp=0; samp<num_input_samps; samp++){
-     input_y[samp] = y1[samp];
+        input_y[samp] = y1[samp];
     }
     double t0 = x1[0];
     double dT = x1[1]-x1[0];

--- a/Tools.cc
+++ b/Tools.cc
@@ -553,16 +553,23 @@ void Tools::SincInterpolation(int n1, double *x1, double *y1, int n2, double *x2
     auto interpolator = boost::math::interpolators::whittaker_shannon<std::vector<double>>(std::move(input_y), t0, dT);
 
     for(int samp=0; samp<n2; samp++){
-        if(x2[samp]<first_input_sample || x2[samp]>last_input_sample){
-            // check if the sample comes before the first sample of the input array (x1[0])
-            // or after the last sample of the input array (x1[n1-1])
-            // if so, then we are asking for the function to *extrapolate*, not *interpolate*
-            // and the results might be surprising...
-            printf("WARNING! You have asked to evaluate the interpolation at (%.2f)\n",x2[samp]);
-            printf("This is outside of the range of support for this function (%.2f - %.2f)\n",first_input_sample, last_input_sample);
-            printf("Behavior may be unexpected! You have been warned...\n");
+    	// check if the sample comes before the first sample of the input array (x1[0])
+        // or after the last sample of the input array (x1[n1-1])
+        // if so, then we are asking for the function to *extrapolate*, not *interpolate*
+        // just use the first/last sample, which replicates the behavior in SimpleLinearInterpolation_OutZero
+        
+        if(x2[samp]<first_input_sample){
+        	// before first sample, use first sample y1
+        	y2[samp] = y1[0];
         }
-        y2[samp] = interpolator(x2[samp]);
+        else if(x2[samp]>last_input_sample){
+        	// after last sample, use last sample of y1
+            y2[samp] = y1[n1-1];
+        }
+        else{
+        	// in the range of support, do interpolation
+        	y2[samp] = interpolator(x2[samp]);
+        }
     }
 }
 

--- a/Tools.cc
+++ b/Tools.cc
@@ -506,6 +506,26 @@ void Tools::NormalTimeOrdering_InvT(const int n,double *volts) {
 
 }
 
+//! A function to do since interpolation from time basis of x1 to the time basis of x2
+/*!
+    
+    The function takes an input array (defined by n1, x1, y1), and interpolates
+    that data to a new time base, provided by x2, and puts the values into y2.
+    The user must therefore provide the number of input samples (n1)
+    and the x and y values of the data to be interpolated (x1, y1).
+    The user must also provide the number of points at which they would like
+    the function interpolated (n2) and the x-values where the function is to be
+    interpolation (x2). The content of y2[i] will be replaced with the interpolated values.
+
+    \param n1 number of points in the input array
+    \param x1 array of points representing the x-values of the input array
+    \param y1 array of points representing the y-values of the input array
+    \param n2 number of points in the output array
+    \param x1 array of points representing the x-values of the output array
+    \param y1 array of points representing the y-values of the output array
+    \return void
+*/
+
 void Tools::SincInterpolation(int n1, double *x1, double *y1, int n2, double *x2, double *y2){
 
     /*

--- a/Tools.cc
+++ b/Tools.cc
@@ -7,6 +7,7 @@
 #include "TSpline.h"
 #include "TH2F.h"
 #include "Constants.h"
+#include <boost/math/interpolators/whittaker_shannon.hpp>
 
 using std::cout;
 

--- a/Tools.h
+++ b/Tools.h
@@ -66,6 +66,7 @@ class Tools {
     static void GetNext2NumbersAsString(ifstream& fin,ofstream& fout,string& number1,string& number2, string& stherest);
     static void GetNextNumberAsString(ifstream& fin,ofstream& fout,string& number);
 
+    static void SincInterpolation(int n1, double *x1, double *y1, int n2, double *x2, double *y2 );
     static void SimpleLinearInterpolation(int n1, double *x1, double *y1, int n2, double *x2, double *y2 );
     static void SimpleLinearInterpolation_OutZero(int n1, double *x1, double *y1, int n2, double *x2, double *y2 );
     static double SimpleLinearInterpolation_extend_Single(int n1, double *x1, double *y1, double x2 );

--- a/log.txt
+++ b/log.txt
@@ -1592,3 +1592,15 @@ coefficients that are needed in order to do noise calculations.
 
 Added the Chiba in-situ antenna model as a ANTENNA_MODE=4 option.
 Related documents in DocBD: http://ara.physics.wisc.edu/docs/0018/001838/001/AntennaModel_20190227.pdf
+
+============================================================================
+ 2020/11/24 Brian Clark
+
+Add a new interpolation function (SincInterpolation) to the Tools class.
+This method of interpolation is useful for preserving relative spectral power.
+Linear interpolation (the default currently used in AraSim) can artifact
+the spectrum of a signal at high frequencies. This requires Boost > 1.71.00 though!
+Boost is chosen to do the interpolation (instead of GSL, ROOT, etc.)
+because AraSim already has boost as a dependency, and boost has a nice interface
+to the sinc/Whittaker-Shannon method.
+as a dependency 


### PR DESCRIPTION
This pull request adds a `SincInterpolation` routine to the Tools class. This uses the boost Whittaker-Shannon algorithm (https://www.boost.org/doc/libs/1_71_0/libs/math/doc/html/math_toolkit/whittaker_shannon.html) to do the interpolation.

This method of interpolation is useful for preserving relative spectral power (https://en.wikipedia.org/wiki/Whittaker–Shannon_interpolation_formula). Linear interpolation (the default currently used in AraSim) can artifact the spectrum of a signal at high frequencies. Attached is a plot showing this effect on a neutrino (properties are below), where the Linear interpolator (1) does not preserve the peak amplitude well, (2) adds substantial out-of-band power content to the spectrum, and (3) alters the relative spectral content of the signal by attenuating the high frequencies. The sinc interpolator has much better behavior.

![time_domain_comparison](https://user-images.githubusercontent.com/12088924/100166977-8ca2b900-2e83-11eb-8201-44bbb770bb31.png)

This update does require boost >=1.71.00. For some users, this will require an upgrade. ARA cvmfs trunk is already using boost 1.74.00, so hopefully this will not affect too many users in the production context.

Boost is chosen to do the interpolation (instead of GSL, ROOT, etc.) because AraSim already has boost as a dependency, and boost has a nice interface to the sinc/Whittaker-Shannon method.

Properties of the sample neutrino (in AraSim "read-in" mode):
//evid nuflavorint nu_nubar pnu currentint posnu_r posnu_theta posnu_phi nnu_theta nnu_phi elast_y
00000001 1 1 20.000 0 2585.7312 -0.4323 5.7594 2.2159 8.8515 0.6419