### PR TITLE
update the GetAngleAnt function

### DIFF
--- a/Report.cc
+++ b/Report.cc
@@ -4361,25 +4361,20 @@ void Report::ApplyNoiseFig_databin(int ch, int bin_n, Detector *detector, double
 
 void Report::GetAngleAnt(Vector &rec_vector, Position &antenna, double &ant_theta, double &ant_phi) {   //ant_theta and ant_phi is in degree 
 
-    // need to fix some parts.
-    // currently phi is not correct.
-    // I think we have to actually rotate (0,-1,0) to antenna location and get phi from rotated (0,-1,0)
-    ant_theta = rec_vector.Angle(antenna)*DEGRAD;
+    /*
+     * 2020-12-07 BAC
+     * We take the receive vector, which currently specificies where the signal is *going*
+     * And flip it to specify where the signal is *coming from*
+     * And then get the theta and phi, and return them in *degrees*.
+     *
+     * This is necessary because AraSim requires antenna_theta and antenna_phi
+     * to indicate "where the signal came from" in order to correctly
+     * calculate the polarization factors and the gain.
+    */
 
-    Vector unit0_10;
-    Vector unit100;
-    unit0_10.SetXYZ(0,-1,0);
-    unit100.SetXYZ(1,0,0);
-    Vector proj;
-
-    proj = antenna.Cross( rec_vector.Cross(antenna) );
-
-    if (proj * unit100 > 0.) {  // rec_vector is pointing to positive x direction
-        ant_phi = 360. - ( proj.Angle(unit0_10) )*DEGRAD;
-    }
-    else {
-        ant_phi = proj.Angle(unit0_10) * DEGRAD;
-    }
+    Vector flip_receive_vector = -1. * receive_vector;
+    antenna_theta = flip_receive_vector.Theta() * TMath::RadToDeg(); // return in degrees
+    antenna_phi = flip_receive_vector.Phi() * TMath::RadToDeg();
 
 }
 

--- a/Report.cc
+++ b/Report.cc
@@ -2841,7 +2841,10 @@ void Report::Connect_Interaction_Detector (Event *event, Detector *detector, Ray
 
 void Report::rerun_event(Event *event, Detector *detector, 
     RaySolver *raysolver, Signal *signal, 
-    IceModel *icemodel, Settings *settings){
+    IceModel *icemodel, Settings *settings,
+    vector<int> &numSolutions, vector<vector<vector<double> > > &traceTimes,
+    vector<vector<vector<double> > > &traceVoltages
+    ){
 
     // we create T_forint, which is the final time sampling of the traces before they are combined
     double RandomTshift = 0. ; // for replication, we have no choice by to set this
@@ -2856,7 +2859,9 @@ void Report::rerun_event(Event *event, Detector *detector,
 
     for(int j=0; j<num_strings; j++){
         for(int k=0; k<num_antennas; k++){
-            
+
+            int idx = ((j*4)+k);
+
             // redo the ray tracing
             vector<vector<double> > ray_output;
             vector<vector<vector<double> > > Ray_Step;
@@ -2866,6 +2871,9 @@ void Report::rerun_event(Event *event, Detector *detector,
 
             // if there is a solution
             if (raysolver->solution_toggle){
+
+                // numSolutions[idx]=ray_output[0].size();
+                numSolutions[idx]=ray_output[0].size();
 
                 int ray_sol_cnt=0;
                 while (ray_sol_cnt < ray_output[0].size()){
@@ -3041,6 +3049,12 @@ void Report::rerun_event(Event *event, Detector *detector,
                     // fix the normalization on the inverse fft (2/N)
                     for(int n=0; n<settings->NFOUR/2; n++){
                         volts_forint[n] *= 2./Nnew;
+                    }
+
+                    // store the result
+                    for(int n=0; n<settings->NFOUR/2; n++){
+                        traceTimes[idx][ray_sol_cnt][n] = T_forint[n];
+                        traceVoltages[idx][ray_sol_cnt][n] = volts_forint[n];
                     }
 
                     ray_sol_cnt++;

--- a/Report.cc
+++ b/Report.cc
@@ -147,7 +147,6 @@ void Antenna_r::clear() {   // if any vector variable added in Antenna_r, need t
     view_ang.clear();
     launch_ang.clear();
     rec_ang.clear();
-    rec_ang_phi.clear();
     reflect_ang.clear();
     Dist.clear();
     L_att.clear();
@@ -159,6 +158,10 @@ void Antenna_r::clear() {   // if any vector variable added in Antenna_r, need t
     Mag.clear();
     Fresnel.clear();
     Pol_factor.clear();
+    Pol_factorH.clear();
+    Pol_factorV.clear();
+    phi_rec.clear();
+    theta_rec.clear();
     //VHz_antfactor.clear();
     //VHz_filter.clear();
     Vfft.clear();
@@ -332,6 +335,10 @@ void Report::Connect_Interaction_Detector (Event *event, Detector *detector, Ray
     double fresnel;                                 // fresnel factor
     double Pol_factor;                              // polarization factor
     double tmp; // for non use return values
+    double Pol_factorV;
+    double Pol_factorH;
+    double phi_rec;
+    double theta_rec;
 
     double freq_tmp, heff, antenna_theta, antenna_phi;  // values needed for apply antenna gain factor and prepare fft, trigger
     double volts_forfft[settings1->NFOUR/2];       // array for fft
@@ -551,8 +558,6 @@ void Report::Connect_Interaction_Detector (Event *event, Detector *detector, Ray
 
                                    GetAngleAnt(receive_vector, detector->stations[i].strings[j].antennas[k], antenna_theta, antenna_phi);   // get theta, phi for signal ray arrived at antenna
                                    //cout<<"antenna theta : "<<antenna_theta<<"  phi : "<<antenna_phi<<endl;  
-                                   stations[i].strings[j].antennas[k].rec_ang_phi.push_back(antenna_phi*PI/180.); // store the antenna phi in radians (!)
-
 
                                    // old freq domain signal mode (AVZ model)
                                    if ( settings1->SIMULATION_MODE == 0 ) {
@@ -1043,6 +1048,17 @@ void Report::Connect_Interaction_Detector (Event *event, Detector *detector, Ray
 
 
 					       stations[i].strings[j].antennas[k].Pol_factor.push_back(Pol_factor);
+                 Vector thetaHat = Vector(cos(antenna_theta*(PI/180))*cos(antenna_phi*(PI/180)),
+                                          cos(antenna_theta*(PI/180))*sin(antenna_phi*(PI/180)),
+                                          -sin(antenna_theta*(PI/180)));
+
+                 Vector phiHat = Vector(-sin(antenna_phi*(PI/180)),
+                                        cos(antenna_phi*(PI/180)),
+                                        0);
+					       stations[i].strings[j].antennas[k].Pol_factorH.push_back(abs(phiHat * Pol_vector));
+					       stations[i].strings[j].antennas[k].Pol_factorV.push_back(abs(thetaHat * Pol_vector));
+                 stations[i].strings[j].antennas[k].phi_rec.push_back(antenna_phi*(PI/180));
+                 stations[i].strings[j].antennas[k].theta_rec.push_back(antenna_theta*(PI/180));
                                                for (int n=0; n<settings1->NFOUR/2; n++) {
 
                                                    if (settings1->TRIG_ANALYSIS_MODE != 2) { // not pure noise mode (we need signal)
@@ -5402,5 +5418,3 @@ vector<double> Report::getHitTimesVectorHpol(Detector *detector, int station_i){
   return getHitTimesVector(detector, station_i, 1);
   
 }
-
-

--- a/Report.cc
+++ b/Report.cc
@@ -2893,7 +2893,6 @@ void Report::rerun_event(Event *event, Detector *detector,
                         launch_vector, receive_vector,
                         n_trg_slappy, n_trg_pokey
                         );
-
                     // get polarization
                     Vector Pol_vector = GetPolarization(
                         event->Nu_Interaction[0].nnu, launch_vector);
@@ -2907,7 +2906,6 @@ void Report::rerun_event(Event *event, Detector *detector,
                         launch_vector, receive_vector,
                         settings, fresnel, mag, Pol_vector
                         );
-
                     // get arrival angle at the antenna
                     double antenna_theta, antenna_phi;
                     GetAngleAnt(
@@ -2915,7 +2913,6 @@ void Report::rerun_event(Event *event, Detector *detector,
                         detector->stations[0].strings[j].antennas[k],
                         antenna_theta, antenna_phi
                         );
-
                     // this is the 1/R and fresnel and focusing effect
                     double atten_factor = 1. / ray_output[0][ray_sol_cnt] * mag * fresnel;
 
@@ -2941,9 +2938,9 @@ void Report::rerun_event(Event *event, Detector *detector,
                     double T_forfft[Nnew];
 
                     for(int n=0; n<Nnew; n++){
-                        T_forfft[n] = Tarray[local_outbin/2] - (dT_forfft*(double)(Nnew/2 - n));
-                        if ( (n >= Nnew/2 - outbin/2) && (n < Nnew/2 + outbin/2) ) {
-                                V_forfft[n] = Earray[ n - (Nnew/2 - outbin/2) ];
+                        T_forfft[n] = local_Tarray[local_outbin/2] - (dT_forfft*(double)(Nnew/2 - n));
+                        if ( (n >= Nnew/2 - local_outbin/2) && (n < Nnew/2 + local_outbin/2) ) {
+                            V_forfft[n] = local_Earray[ n - (Nnew/2 - local_outbin/2) ];
                         }
                         else{
                             V_forfft[n] = 0.;
@@ -2971,15 +2968,15 @@ void Report::rerun_event(Event *event, Detector *detector,
                     double attenuations[Nnew/2];
                     std::fill_n(attenuations, Nnew/2, 1.); // all of the attenuations initially start at 1
 
-                    for (int steps = 1; steps < (int) RayStep[ray_sol_cnt][0].size(); steps++) {
-                        double dx = RayStep[ray_sol_cnt][0][steps - 1] - RayStep[ray_sol_cnt][0][steps];
-                        double dz = RayStep[ray_sol_cnt][1][steps - 1] - RayStep[ray_sol_cnt][1][steps];
+                    for (int steps = 1; steps < (int) Ray_Step[ray_sol_cnt][0].size(); steps++) {
+                        double dx = Ray_Step[ray_sol_cnt][0][steps - 1] - Ray_Step[ray_sol_cnt][0][steps];
+                        double dz = Ray_Step[ray_sol_cnt][1][steps - 1] - Ray_Step[ray_sol_cnt][1][steps];
                         double dl = sqrt((dx * dx) + (dz * dz));
                         for(int n=0; n<Nnew/2; n++){
                             freq_tmp = dF_Nnew*((double)n+0.5);
                             // use ray midpoint for attenuation calculation
-                            double IceAttenFactor = (  exp(-dl / icemodel->GetFreqDepIceAttenuLength(-RayStep[ray_sol_cnt][1][steps], freq_tmp * 1.E-9))
-                                                        + exp(-dl / icemodel->GetFreqDepIceAttenuLength(-RayStep[ray_sol_cnt][1][steps-1], freq_tmp * 1.E-9))
+                            double IceAttenFactor = (  exp(-dl / icemodel->GetFreqDepIceAttenuLength(-Ray_Step[ray_sol_cnt][1][steps], freq_tmp * 1.E-9))
+                                                        + exp(-dl / icemodel->GetFreqDepIceAttenuLength(-Ray_Step[ray_sol_cnt][1][steps-1], freq_tmp * 1.E-9))
                                                     )/2.; // 1e9 for conversion to GHz
                             // increase the attenuation
                             attenuations[n]*=IceAttenFactor;

--- a/Report.cc
+++ b/Report.cc
@@ -4372,9 +4372,9 @@ void Report::GetAngleAnt(Vector &rec_vector, Position &antenna, double &ant_thet
      * calculate the polarization factors and the gain.
     */
 
-    Vector flip_receive_vector = -1. * receive_vector;
-    antenna_theta = flip_receive_vector.Theta() * TMath::RadToDeg(); // return in degrees
-    antenna_phi = flip_receive_vector.Phi() * TMath::RadToDeg();
+    Vector flip_receive_vector = -1. * rec_vector;
+    ant_theta = flip_receive_vector.Theta() * TMath::RadToDeg(); // return in degrees
+    ant_phi = flip_receive_vector.Phi() * TMath::RadToDeg();
 
 }
 

--- a/Report.cc
+++ b/Report.cc
@@ -2911,7 +2911,8 @@ void Report::rerun_event(Event *event, Detector *detector,
                     double local_Tarray[local_outbin];
                     int local_skipbins;
                     signal->GetVm_FarField_Tarray(event, settings, viewangle,
-                        atten_factor, local_outbin, local_Tarray, local_Earray, local_skipbins);
+                        atten_factor, local_outbin, local_Tarray, local_Earray, local_skipbins
+                        );
 
                     double dT_forfft = local_Tarray[1] - local_Tarray[0];
                     int Ntmp = settings->TIMESTEP*1.e9 / dT_forfft;
@@ -2963,7 +2964,8 @@ void Report::rerun_event(Event *event, Detector *detector,
                         double heff = GaintoHeight(gain, freq_tmp,
                             icemodel->GetN(detector->stations[0].strings[j].antennas[k])
                             );
-                        double phase = detector->GetAntPhase_1D(freq_tmp*1.e-6,
+                        double phase = detector->GetAntPhase_1D(
+                            freq_tmp*1.E-6, // Hz
                             antenna_theta, antenna_phi, 
                             detector->stations[0].strings[j].antennas[k].type
                             );
@@ -3009,21 +3011,22 @@ void Report::rerun_event(Event *event, Detector *detector,
                                 V_forfft[2*n], V_forfft[2*n + 1]
                                 );
                         }
-
-                        // back to time domain
-                        Tools::realft(V_forfft, -1, Nnew);
-
-                        double volts_forint[settings->NFOUR/2];
-                        double T_forint[settings->NFOUR/2];
-                        Tools::SincInterpolation(Nnew, T_forfft, V_forfft,
-                            settings->NFOUR/2, T_forint, volts_forint
-                            );
-
-                        // // we have to fix the normalization on the inverse fft (2/N)
-                        // for(int n=0; n<settings->NFOUR/2; n++){
-                        //     volts_forint[n] *= 2./Nnew;
-                        // }
                     }
+
+                    // back to time domain
+                    Tools::realft(V_forfft, -1, Nnew);
+
+                    // double volts_forint[settings->NFOUR/2];
+                    // double T_forint[settings->NFOUR/2];
+                    // Tools::SincInterpolation(Nnew, T_forfft, V_forfft,
+                    //     settings->NFOUR/2, T_forint, volts_forint
+                    //     );
+
+                    // // we have to fix the normalization on the inverse fft (2/N)
+                    // for(int n=0; n<settings->NFOUR/2; n++){
+                    //     volts_forint[n] *= 2./Nnew;
+                    // }
+
                     ray_sol_cnt++;
                 }
             }

--- a/Report.cc
+++ b/Report.cc
@@ -2841,10 +2841,23 @@ void Report::Connect_Interaction_Detector (Event *event, Detector *detector, Ray
 
 void Report::rerun_event(Event *event, Detector *detector, 
     RaySolver *raysolver, Signal *signal, 
-    IceModel *icemodel, Settings *settings,
+    IceModel *icemodel, Settings *settings, int which_solution,
     vector<int> &numSolutions, vector<vector<vector<double> > > &traceTimes,
     vector<vector<vector<double> > > &traceVoltages
     ){
+
+    // which solution = 0 (direct only), 1 (refracted/reflected only), 2 (both)
+    std::vector<int> which_sols_to_search;
+    if (which_solution==0){
+        which_sols_to_search.push_back(0);
+    }
+    else if(which_solution==1){
+        which_sols_to_search.push_back(1);
+    }
+    else if(which_solution==2){
+        which_sols_to_search.push_back(0);
+        which_sols_to_search.push_back(1);
+    }
 
     // we create T_forint, which is the final time sampling of the traces before they are combined
     double RandomTshift = 0. ; // for replication, we have no choice by to set this
@@ -2877,6 +2890,12 @@ void Report::rerun_event(Event *event, Detector *detector,
 
                 int ray_sol_cnt=0;
                 while (ray_sol_cnt < ray_output[0].size()){
+
+                    if(std::find(which_sols_to_search.begin(), which_sols_to_search.end(), ray_sol_cnt) == which_sols_to_search.end()){
+                        // if this solution is not meant to be searched, skip it
+                        ray_sol_cnt++;
+                        continue;
+                    }
 
                     double viewangle = ray_output[1][ray_sol_cnt];
                     Position launch_vector;

--- a/Report.cc
+++ b/Report.cc
@@ -2856,9 +2856,7 @@ void Report::rerun_event(Event *event, Detector *detector,
 
     for(int j=0; j<num_strings; j++){
         for(int k=0; k<num_antennas; k++){
-
-            printf("On string %i, antenna %i\n",j,k);
-
+            
             // redo the ray tracing
             vector<vector<double> > ray_output;
             vector<vector<vector<double> > > Ray_Step;

--- a/Report.cc
+++ b/Report.cc
@@ -4100,7 +4100,7 @@ double Report::calculatePolFactor(Vector &Pol_vector, int ant_type, double anten
      else if (ant_type == 1) {   // if h pol
          pol_factor = Pol_vector *phiHat;
      }
-     pol_factor = abs(pol_factor);
+     pol_factor = pol_factor;
      return pol_factor;
  }
 

--- a/Report.cc
+++ b/Report.cc
@@ -2906,6 +2906,7 @@ void Report::rerun_event(Event *event, Detector *detector,
                         launch_vector, receive_vector,
                         settings, fresnel, mag, Pol_vector
                         );
+
                     // get arrival angle at the antenna
                     double antenna_theta, antenna_phi;
                     GetAngleAnt(
@@ -2913,6 +2914,7 @@ void Report::rerun_event(Event *event, Detector *detector,
                         detector->stations[0].strings[j].antennas[k],
                         antenna_theta, antenna_phi
                         );
+                    
                     // this is the 1/R and fresnel and focusing effect
                     double atten_factor = 1. / ray_output[0][ray_sol_cnt] * mag * fresnel;
 

--- a/Report.h
+++ b/Report.h
@@ -240,6 +240,7 @@ class Report {
 //    void Connect_Interaction_Detector (Event *event, Detector *detector, RaySolver *raysolver, Signal *signal, IceModel *icemodel, Settings *settings1, Trigger *trigger);
     
     void Connect_Interaction_Detector (Event *event, Detector *detector, RaySolver *raysolver, Signal *signal, IceModel *icemodel, Settings *settings1, Trigger *trigger, int evt);    
+    void rerun_event(Event *event, Detector *detector, RaySolver *raysolver, Signal *signal, IceModel *icemodel, Settings *settings);
     
     
 #ifdef ARA_UTIL_EXISTS

--- a/Report.h
+++ b/Report.h
@@ -240,7 +240,7 @@ class Report {
 //    void Connect_Interaction_Detector (Event *event, Detector *detector, RaySolver *raysolver, Signal *signal, IceModel *icemodel, Settings *settings1, Trigger *trigger);
     
     void Connect_Interaction_Detector (Event *event, Detector *detector, RaySolver *raysolver, Signal *signal, IceModel *icemodel, Settings *settings1, Trigger *trigger, int evt);    
-    void rerun_event(Event *event, Detector *detector, RaySolver *raysolver, Signal *signal, IceModel *icemodel, Settings *settings,
+    void rerun_event(Event *event, Detector *detector, RaySolver *raysolver, Signal *signal, IceModel *icemodel, Settings *settings, int which_solution,
         vector<int> &numSolutions, vector<vector<vector<double> > > &traceTimes, vector<vector<vector<double> > > &traceVoltages
         );
     

--- a/Report.h
+++ b/Report.h
@@ -56,7 +56,6 @@ class Antenna_r {
         vector <double> view_ang;    //viewing angle
         vector <double> launch_ang;  //launch angle
         vector <double> rec_ang;     //receiving angle phi (in radians)
-        vector <double> rec_ang_phi; // receiving angle phi (in radians)
         vector <double> reflect_ang; // surface reflection angle (if 100 : no reflection case)
         vector <double> Dist;        //Distance between posnu and antenna
         vector <double> L_att;        //Attenuation factor

--- a/Report.h
+++ b/Report.h
@@ -240,8 +240,9 @@ class Report {
 //    void Connect_Interaction_Detector (Event *event, Detector *detector, RaySolver *raysolver, Signal *signal, IceModel *icemodel, Settings *settings1, Trigger *trigger);
     
     void Connect_Interaction_Detector (Event *event, Detector *detector, RaySolver *raysolver, Signal *signal, IceModel *icemodel, Settings *settings1, Trigger *trigger, int evt);    
-    void rerun_event(Event *event, Detector *detector, RaySolver *raysolver, Signal *signal, IceModel *icemodel, Settings *settings);
-    
+    void rerun_event(Event *event, Detector *detector, RaySolver *raysolver, Signal *signal, IceModel *icemodel, Settings *settings,
+        vector<int> &numSolutions, vector<vector<vector<double> > > &traceTimes, vector<vector<vector<double> > > &traceVoltages
+        );
     
 #ifdef ARA_UTIL_EXISTS
 

--- a/Report.h
+++ b/Report.h
@@ -56,6 +56,8 @@ class Antenna_r {
         vector <double> view_ang;    //viewing angle
         vector <double> launch_ang;  //launch angle
         vector <double> rec_ang;     //receiving angle phi (in radians)
+        vector <double> phi_rec;     // receiving phi angle,in antenna's coord system.
+        vector <double> theta_rec;     // receiving theta angle, in antenna's coord system.
         vector <double> reflect_ang; // surface reflection angle (if 100 : no reflection case)
         vector <double> Dist;        //Distance between posnu and antenna
         vector <double> L_att;        //Attenuation factor
@@ -72,6 +74,8 @@ class Antenna_r {
         vector <double> Mag;  // magnification factor
         vector <double> Fresnel;  // Fresnel factor
         vector <double> Pol_factor;  // Polarization factor
+        vector <double> Pol_factorH;  //Hpol Polarization factor
+        vector <double> Pol_factorV;  //Vpol Polarization factor
         
         vector < vector <double> > Vm_zoom;  // E field before ant T-domain
         vector < vector <double> > Vm_zoom_T;  // E field before ant T-domain time

--- a/Settings.cc
+++ b/Settings.cc
@@ -88,6 +88,8 @@ outputdir="outputs"; // directory where outputs go
 
   SIMULATION_MODE=1;    // default freq domain simulation
 
+  USE_PARAM_RE_TTERM_TABLE=1; // default: use the interpolation table to get Param_RE_TTerm
+
   EVENT_TYPE=0;         // default neutrino only events
 
   WAVE_TYPE=0;          // default wave type : plane wave (inside the ice)
@@ -359,6 +361,9 @@ void Settings::ReadFile(string setupfile) {
               }
               else if (label == "SIMULATION_MODE") {
                   SIMULATION_MODE = atof( line.substr(line.find_first_of("=") + 1).c_str() );
+              }
+              else if (label == "USE_PARAM_RE_TTERM_TABLE") {
+                  USE_PARAM_RE_TTERM_TABLE = atof( line.substr(line.find_first_of("=") + 1).c_str() );
               }
               else if (label == "EVENT_TYPE") {
                   EVENT_TYPE = atof( line.substr(line.find_first_of("=") + 1).c_str() );
@@ -971,6 +976,12 @@ int Settings::CheckCompatibilitiesSettings() {
    if (DETECTOR_STATION==0 && DETECTOR!=3){
       cerr << " DETECTOR_STATION=0 doesn't work with DETECTOR!=3. If you want to work with TestBed, use DETECTOR=3 & DETECTOR_STATION=0" << endl;
       num_err++;
+   }
+
+   // check that USE_PARAM_RE_TTERM_TABLE is only used with SIMULATION_MODE==1
+   if (USE_PARAM_RE_TTERM_TABLE==1 && SIMULATION_MODE!=1){
+    cerr << "USE_PARAM_RE_TTERM_TABLE=0 doesn't work with SIMULATION_MODE!=1"<<endl;
+    num_err++;
    }
 
 

--- a/Settings.h
+++ b/Settings.h
@@ -66,6 +66,8 @@ class Settings
 
         int SIMULATION_MODE;    // 0 : old freq domain mode, 1: new time domain mode
 
+        int USE_PARAM_RE_TTERM_TABLE; // 1 (default): use the table, 0: do not use the table (takes ~10x longer)
+
         int EVENT_TYPE;         // 0 : neutrino only events,  1 : blackhole evnet? ... etc
 
         int WAVE_TYPE;          // 0 : plane wave,  1 : spherical wave

--- a/log.txt
+++ b/log.txt
@@ -1604,3 +1604,16 @@ Boost is chosen to do the interpolation (instead of GSL, ROOT, etc.)
 because AraSim already has boost as a dependency, and boost has a nice interface
 to the sinc/Whittaker-Shannon method.
 as a dependency 
+
+============================================================================
+2020/12/07 Brian Clark
+
+Update the GetAngleAnt function for a correct calculation of antenna_theta
+and antenna_phi. This fixes two things. 
+First, GetAngleAnt was not calculating antenna_phi correctly.
+Second, GetAngleAnt was calculating antenna_theta so that it indicated
+where the signal was  *going*. But antenna_theta needs to indicate where the signal
+*came from* in order to be used correctly in the new pol factor calculation (see above)
+and in the antenna gain calculation. This bug would so far have not impacted
+AraSim sensitivity estimates because the antennas are approximately
+azimuthally and zenithally symmetric.

--- a/log.txt
+++ b/log.txt
@@ -1626,3 +1626,13 @@ Add a new mode (USE_PARAM_RE_TTERM_TABLE=1) which allows the user to evaluate
 the Param_RE_TTerm using a lookup table w/ interpolation instead of computing
 it on the fly. This increases the speed of the shower integral by more than an order
 of magnitude.
+
+============================================================================
+2021/01/23 Brian Clark
+
+Make a slight modification to the Solve_Ray function in RaySolver.cc.
+This ensures that the ray output results are always returned with the direct
+solution first and the refracted/reflected solutions second.
+Testing (on a few hundred events) suggested that direct solutions
+are always returned first anyway, but this guarantees it, which can be useful
+for debugging.

--- a/log.txt
+++ b/log.txt
@@ -1617,3 +1617,12 @@ where the signal was  *going*. But antenna_theta needs to indicate where the sig
 and in the antenna gain calculation. This bug would so far have not impacted
 AraSim sensitivity estimates because the antennas are approximately
 azimuthally and zenithally symmetric.
+
+
+============================================================================
+2020/12/10 Brian Clark
+
+Add a new mode (USE_PARAM_RE_TTERM_TABLE=1) which allows the user to evaluate
+the Param_RE_TTerm using a lookup table w/ interpolation instead of computing
+it on the fly. This increases the speed of the shower integral by more than an order
+of magnitude.

--- a/signal.cc
+++ b/signal.cc
@@ -251,11 +251,14 @@ Signal::~Signal() {
       //cout<<"whichparameterization : "<<WHICHPARAMETERIZATION<<"\n";
   }
 
+  if (settings1->SIMULATION_MODE==1){
+    Build_Param_RE_Tterm_tables();
+  }
+
   
 
 
 }
-
 
  void Signal::ReadCalPulserSpectrum(){
     int frequency;
@@ -861,13 +864,78 @@ double Signal::Greisen(double x_in, double *par) {
 
 }
 
+void Signal::get_Param_RA(int em_or_had, double (&the_params)[8]){
+  /*
+  Depending on if em_or_had = 0 or 1 (0 = EM, 1 = HAD)
+  Assing the parameters
+  */
 
+  if(em_or_had==0){
+    the_params[0] = 0.057;
+    the_params[1] = 2.87;
+    the_params[2] = -3.;
+
+    the_params[3] = -0.03;
+    the_params[4] = -3.05;
+    the_params[5] = -3.5;
+  }
+  else if(em_or_had==1){
+    the_params[0] = 0.043;
+    the_params[1] = 2.92;
+    the_params[2] = -3.21;
+
+    the_params[3] = -0.065;
+    the_params[4] = -3.00;
+    the_params[5] = -2.65;    
+  }
+
+}
+
+double Signal::evaluate_param_re_table(double time, std::vector<double> &table){
+  double ans = 0;
+  if( time > tables_t_min && time < tables_t_max){
+    int low_bin = (time - tables_t_min)*tables_inv_dt; // low bin
+    int hi_bin = low_bin+1; // hi bin
+    double frac = (time - (low_bin*tables_dt + tables_t_min))*tables_inv_dt; // which bin is it closer to
+    ans = table[low_bin]*(frac) + table[hi_bin]*(1.-frac); // evaluate
+  }
+  return ans;
+}
+
+std::vector<double> Signal::pick_table(int em_or_had){
+  if(em_or_had==0){
+    return tterm_table_em;
+  }
+  else{
+    return tterm_table_had;
+  }
+}
+
+void Signal::Build_Param_RE_Tterm_tables(){
+  cout<<"Building the Param RE Tterm tables..."<<endl;
+  tables_dt = 0.001;
+  tables_inv_dt = 1./tables_dt;
+  tables_max_t = 100.;
+  tables_t_min = (-tables_max_t) + tables_dt/2.; // start it 1/2 sample "in" so that it "hops" time = 0
+  tables_t_max = (tables_max_t) - tables_dt/2.; 
+  int table_num_bins = int((tables_max_t/tables_dt)*2);
+
+  double param_RA_em[8];
+  double param_RA_had[8];
+  get_Param_RA(0, param_RA_em);
+  get_Param_RA(1, param_RA_had);
+
+  for(int i=0; i<table_num_bins; i++){
+    double time = (i*tables_dt) + tables_t_min;
+    tterm_table_em.push_back(Param_RE_Tterm(time, param_RA_em));
+    tterm_table_had.push_back(Param_RE_Tterm(time, param_RA_had));
+  }
+  cout<<"Finished building the Param RE Tterm tables."<<endl;
+}
 
 
 // depending on the shower_mode, make Vm array for em shower/had shower or both
 void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double viewangle, double atten_factor, int outbin, double *Tarray, double *Earray, int &skip_bins ) {
-
-
 
     double sin_view = sin(viewangle);
     double cos_view = cos(viewangle);
@@ -899,6 +967,7 @@ void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double vi
         Tarray[tbin] = 0.;
         Earray[tbin] = 0.;
     }
+    std::vector<double> the_table_to_use;
 
 
     // if we drive Askaryan signal from only one shower
@@ -911,13 +980,8 @@ void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double vi
         //if ( event->Nu_Interaction[0].primary_shower == 0 ) {
 
             V_s = -4.5e-14;
-            param_RA[0] = 0.057;
-            param_RA[1] = 2.87;
-            param_RA[2] = -3.;
-
-            param_RA[3] = -0.03;
-            param_RA[4] = -3.05;
-            param_RA[5] = -3.5;
+            get_Param_RA(0, param_RA);
+            the_table_to_use = pick_table(0);
 
             E_shower = event->pnu*event->Nu_Interaction[0].emfrac;
 
@@ -937,13 +1001,10 @@ void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double vi
         //else if ( event->Nu_Interaction[0].primary_shower == 1 ) {
 
             V_s = -3.2e-14;
-            param_RA[0] = 0.043;
-            param_RA[1] = 2.92;
-            param_RA[2] = -3.21;
+            get_Param_RA(1, param_RA);
+            the_table_to_use = pick_table(1);
 
-            param_RA[3] = -0.065;
-            param_RA[4] = -3.00;
-            param_RA[5] = -2.65;
+
 
             //E_shower = event->pnu*event->Nu_Interaction[0].emfrac;
             E_shower = event->pnu*event->Nu_Interaction[0].hadfrac;
@@ -969,13 +1030,9 @@ void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double vi
             if ( event->Nu_Interaction[0].primary_shower == 0 ) {
 
                 V_s = -4.5e-14;
-                param_RA[0] = 0.057;
-                param_RA[1] = 2.87;
-                param_RA[2] = -3.;
+                get_Param_RA(0, param_RA);
+                the_table_to_use = pick_table(0);
 
-                param_RA[3] = -0.03;
-                param_RA[4] = -3.05;
-                param_RA[5] = -3.5;
 
                 E_shower = event->pnu*event->Nu_Interaction[0].emfrac;
 
@@ -991,13 +1048,9 @@ void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double vi
             else if ( event->Nu_Interaction[0].primary_shower == 1 ) {
 
                 V_s = -3.2e-14;
-                param_RA[0] = 0.043;
-                param_RA[1] = 2.92;
-                param_RA[2] = -3.21;
+                get_Param_RA(1, param_RA);
+                the_table_to_use = pick_table(1);
 
-                param_RA[3] = -0.065;
-                param_RA[4] = -3.00;
-                param_RA[5] = -2.65;
 
                 //E_shower = event->pnu*event->Nu_Interaction[0].emfrac;
                 E_shower = event->pnu*event->Nu_Interaction[0].hadfrac;
@@ -1092,7 +1145,8 @@ void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double vi
 
                     //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[bin]) * Param_RE_Tterm(Tterm, param_RA);
                     //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm(Tterm, param_RA);
-                    Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
+                    // Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
+                    Integrate += -1 *(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * evaluate_param_re_table(Tterm, the_table_to_use);
                 }
 
             }
@@ -1118,13 +1172,9 @@ void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double vi
             EM_shower_on = 1;
 
             V_s = -4.5e-14;
-            param_RA[0] = 0.057;
-            param_RA[1] = 2.87;
-            param_RA[2] = -3.;
+            get_Param_RA(0, param_RA);
+            the_table_to_use = pick_table(0);
 
-            param_RA[3] = -0.03;
-            param_RA[4] = -3.05;
-            param_RA[5] = -3.5;
 
             E_shower = event->pnu*event->Nu_Interaction[0].emfrac;
 
@@ -1210,7 +1260,8 @@ void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double vi
                         //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[bin]) * Param_RE_Tterm(Tterm, param_RA);
                         //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm(Tterm, param_RA);
                         //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
-                        Integrate += -1.*(event->Nu_Interaction[0].EM_shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
+                        // Integrate += -1.*(event->Nu_Interaction[0].EM_shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
+                        Integrate += -1 *(event->Nu_Interaction[0].EM_shower_Q_profile[mid_old_bin]) * evaluate_param_re_table(Tterm, tterm_table_em);
                     }
 
                 }
@@ -1231,13 +1282,8 @@ void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double vi
         if ( event->Nu_Interaction[0].HAD_LQ > 0 ) {
 
             V_s = -3.2e-14;
-            param_RA[0] = 0.043;
-            param_RA[1] = 2.92;
-            param_RA[2] = -3.21;
-
-            param_RA[3] = -0.065;
-            param_RA[4] = -3.00;
-            param_RA[5] = -2.65;
+            get_Param_RA(1, param_RA);
+            the_table_to_use = pick_table(1);
 
             //E_shower = event->pnu*event->Nu_Interaction[0].emfrac;
             E_shower = event->pnu*event->Nu_Interaction[0].hadfrac;
@@ -1336,7 +1382,8 @@ void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double vi
                         //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[bin]) * Param_RE_Tterm(Tterm, param_RA);
                         //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm(Tterm, param_RA);
                         //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
-                        Integrate += -1.*(event->Nu_Interaction[0].HAD_shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
+                        // Integrate += -1.*(event->Nu_Interaction[0].HAD_shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
+                        Integrate += -1 *(event->Nu_Interaction[0].HAD_shower_Q_profile[mid_old_bin]) * evaluate_param_re_table(Tterm, tterm_table_had);
                     }
 
                 }

--- a/signal.cc
+++ b/signal.cc
@@ -1265,7 +1265,7 @@ void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double vi
                         //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm(Tterm, param_RA);
                         //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
                         if(settings1->USE_PARAM_RE_TTERM_TABLE==1){
-                    		Integrate += -1 *(event->Nu_Interaction[0].EM_shower_Q_profile[mid_old_bin]) * evaluate_param_re_table(Tterm, tterm_table_em);
+                    		  Integrate += -1 *(event->Nu_Interaction[0].EM_shower_Q_profile[mid_old_bin]) * evaluate_param_re_table(Tterm, tterm_table_em);
                         }
                         else{
                         	Integrate += -1.*(event->Nu_Interaction[0].EM_shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);                        		

--- a/signal.cc
+++ b/signal.cc
@@ -927,8 +927,8 @@ void Signal::Build_Param_RE_Tterm_tables(){
 
   for(int i=0; i<table_num_bins; i++){
     double time = (i*tables_dt) + tables_t_min;
-    tterm_table_em.push_back(Param_RE_Tterm_approx(time, param_RA_em));
-    tterm_table_had.push_back(Param_RE_Tterm_approx(time, param_RA_had));
+    tterm_table_em.push_back(Param_RE_Tterm(time, param_RA_em));
+    tterm_table_had.push_back(Param_RE_Tterm(time, param_RA_had));
   }
   cout<<"Finished building the Param RE Tterm tables."<<endl;
 }

--- a/signal.cc
+++ b/signal.cc
@@ -913,9 +913,9 @@ std::vector<double> Signal::pick_table(int em_or_had){
 
 void Signal::Build_Param_RE_Tterm_tables(){
   cout<<"Building the Param RE Tterm tables..."<<endl;
-  tables_dt = 0.001;
+  tables_dt = 0.0001;
   tables_inv_dt = 1./tables_dt;
-  tables_max_t = 100.;
+  tables_max_t = 75.;
   tables_t_min = (-tables_max_t) + tables_dt/2.; // start it 1/2 sample "in" so that it "hops" time = 0
   tables_t_max = (tables_max_t) - tables_dt/2.; 
   int table_num_bins = int((tables_max_t/tables_dt)*2);
@@ -927,8 +927,8 @@ void Signal::Build_Param_RE_Tterm_tables(){
 
   for(int i=0; i<table_num_bins; i++){
     double time = (i*tables_dt) + tables_t_min;
-    tterm_table_em.push_back(Param_RE_Tterm(time, param_RA_em));
-    tterm_table_had.push_back(Param_RE_Tterm(time, param_RA_had));
+    tterm_table_em.push_back(Param_RE_Tterm_approx(time, param_RA_em));
+    tterm_table_had.push_back(Param_RE_Tterm_approx(time, param_RA_had));
   }
   cout<<"Finished building the Param RE Tterm tables."<<endl;
 }
@@ -1145,8 +1145,12 @@ void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double vi
 
                     //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[bin]) * Param_RE_Tterm(Tterm, param_RA);
                     //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm(Tterm, param_RA);
-                    // Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
-                    Integrate += -1 *(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * evaluate_param_re_table(Tterm, the_table_to_use);
+                    if(settings1->USE_PARAM_RE_TTERM_TABLE==1){
+                    	Integrate += -1 *(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * evaluate_param_re_table(Tterm, the_table_to_use);
+                    }
+                    else{
+                    	Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
+                    }
                 }
 
             }
@@ -1260,8 +1264,13 @@ void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double vi
                         //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[bin]) * Param_RE_Tterm(Tterm, param_RA);
                         //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm(Tterm, param_RA);
                         //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
-                        // Integrate += -1.*(event->Nu_Interaction[0].EM_shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
-                        Integrate += -1 *(event->Nu_Interaction[0].EM_shower_Q_profile[mid_old_bin]) * evaluate_param_re_table(Tterm, tterm_table_em);
+                        if(settings1->USE_PARAM_RE_TTERM_TABLE==1){
+                    		Integrate += -1 *(event->Nu_Interaction[0].EM_shower_Q_profile[mid_old_bin]) * evaluate_param_re_table(Tterm, tterm_table_em);
+                        }
+                        else{
+                        	Integrate += -1.*(event->Nu_Interaction[0].EM_shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);                        		
+                        }
+
                     }
 
                 }
@@ -1382,8 +1391,12 @@ void Signal::GetVm_FarField_Tarray( Event *event, Settings *settings1, double vi
                         //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[bin]) * Param_RE_Tterm(Tterm, param_RA);
                         //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm(Tterm, param_RA);
                         //Integrate += -1.*(event->Nu_Interaction[0].shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
-                        // Integrate += -1.*(event->Nu_Interaction[0].HAD_shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);
-                        Integrate += -1 *(event->Nu_Interaction[0].HAD_shower_Q_profile[mid_old_bin]) * evaluate_param_re_table(Tterm, tterm_table_had);
+                        if(settings1->USE_PARAM_RE_TTERM_TABLE==1){
+                        	Integrate += -1 *(event->Nu_Interaction[0].HAD_shower_Q_profile[mid_old_bin]) * evaluate_param_re_table(Tterm, tterm_table_had);
+                        }
+                        else{
+                       		Integrate += -1.*(event->Nu_Interaction[0].HAD_shower_Q_profile[mid_old_bin]) * Param_RE_Tterm_approx(Tterm, param_RA);                        	
+                        }
                     }
 
                 }

--- a/signal.hh
+++ b/signal.hh
@@ -182,6 +182,20 @@ double changle; // cherenkov angle
   std::vector<double> ArbitraryWaveform_T;
   void ReadArbitraryWaveform(std::string target);
 
+  // variables needed to precompute the Param_RE_Tterm tables
+  std::vector<double> tterm_table_em;
+  std::vector<double> tterm_table_had;
+  double tables_dt; // time sampling for the tables
+  double tables_inv_dt; // 1/time sampling for the tables
+  double tables_max_t; // half the table window, e.g. = 50 means tables go from -50 to 50
+  double tables_t_min; // start of the table support window
+  double tables_t_max; // end of table support window
+
+  void get_Param_RA(int em_or_had, double (&the_params)[8]);
+  void Build_Param_RE_Tterm_tables();
+  double evaluate_param_re_table(double time, std::vector<double> &table);
+  std::vector<double> pick_table(int em_or_had);
+
 
   void SetMedium(int medium) {
     MEDIUM=medium;


### PR DESCRIPTION
Update the GetAngleAnt function for a correct calculation of `antenna_theta` and `antenna_phi`. This fixes two things. 

First, GetAngleAnt was not calculating `antenna_phi` correctly.

Second, GetAngleAnt was calculating antenna_theta so that it indicated where the signal was  *going*. But `antenna_theta` needs to indicate where the signal *came from* in order to be used correctly in the new pol factor calculation (see above) and in the antenna gain calculation.

This bug would so far have not impacted AraSim sensitivity estimates because the antennas are approximately azimuthally and zenithally symmetric.