### PR TITLE
Add ffttools to replace the AraSim FFT routines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ ifeq ($(strip $(BOOST_ROOT)),)
 	BOOST_ROOT = /usr/local/include
 endif
 
-SYSINCLUDES	= -I/usr/include -I$(BOOST_ROOT) -I$(PLATFORM_DIR)/include
-SYSLIBS         = -L/usr/lib -L$(PLATFORM_DIR)/lib
+SYSINCLUDES	= -I/usr/include -I$(BOOST_ROOT) -I$(PLATFORM_DIR)/include -I${ARA_DEPS_INSTALL_DIR}/include
+SYSLIBS         = -L/usr/lib -L$(PLATFORM_DIR)/lib -L${ARA_DEPS_INSTALL_DIR}/lib
 
 DLLSUF = ${DllSuf}
 OBJSUF = ${ObjSuf}
@@ -34,7 +34,7 @@ ARA_ROOT_FLAGS =
 # added for Fortran to C++
 
 
-LIBS	= $(ROOTLIBS) -lMinuit $(SYSLIBS)
+LIBS	= $(ROOTLIBS) -lMinuit $(SYSLIBS) -lRootFftwWrapper -lfftw3
 GLIBS	= $(ROOTGLIBS) $(SYSLIBS)
 
 ROOT_LIBRARY = libAra.${DLLSUF}

--- a/Tools.cc
+++ b/Tools.cc
@@ -121,7 +121,6 @@ void Tools::realft(double *data, const int isign, int nsize){
     /*
     * This function was specifically engineered by Yuchieh Ku
     * to emulate the interface of the numerical recipes "realft" function
-    * <YUCHIEH WILL ADD MORE DOCUMENTATION HERE>
     * This function has exactly the same input and output formats as the "realft" function in the numerical recipes. 
     * Input array {f1,f2,f3....f_nsize}, after this fcn, it will become {F_0, F_N/2, F_1_r, F_1_c, F_2_r, F_2_c,...} (Forward). 
     * isign: 1/-1 Forward/Inverse FFT.

--- a/Tools.cc
+++ b/Tools.cc
@@ -9,6 +9,10 @@
 #include "Constants.h"
 #include <boost/math/interpolators/whittaker_shannon.hpp>
 
+// fft related
+#include "FFTtools.h"
+#include <fftw3.h>
+
 using std::cout;
 
 void  Tools::MakeGraph(const int n,double *time,double *volts,TGraph *&mygraph,TH2F *&h2, double scalex,double scaley,string xaxistitle,string yaxistitle) {
@@ -101,94 +105,67 @@ void Tools::ShiftRight(double *x,const int n,int ishift) {
 
 }
 
+//! A function to do FFT
+/*!
+    
+    The function performs the FFT on an array data of size nsize
+
+    \param data the data to be transformed
+    \param isign whether you want a forward (1) or reverse (-1) transform
+    \param nsize size of the array to be transformed (must be a factor 2!)
+    \return void
+*/
+
 void Tools::realft(double *data, const int isign, int nsize){
-    int i, i1, i2, i3, i4;
-    double c1=0.5,c2,h1r,h1i,h2r,h2i,wr,wi,wpr,wpi,wtemp,theta;
-    //theta=3.141592653589793238/(nsize>>1);
-    theta=3.141592653589793238/(double)(nsize>>1);
-    if (isign == 1) {
-        c2 = -0.5;
-        four1(data,1,nsize);
-    } else {
-        c2=0.5;
-        theta = -theta;
+
+    /*
+    * This function was specifically engineered by Yuchieh Ku
+    * to emulate the interface of the numerical recipes "realft" function
+    * <YUCHIEH WILL ADD MORE DOCUMENTATION HERE>
+    */
+
+
+    if(isign==1){
+        FFTWComplex *fftarray;
+        fftarray=FFTtools::doFFT(nsize,data);
+        format_transform(nsize, 1, (fftw_complex*)fftarray, data);
     }
-    wtemp=sin(0.5*theta);
-    wpr = -2.0*wtemp*wtemp;
-    wpi=sin(theta);
-    wr=1.0+wpr;
-    wi=wpi;
-    for (i=1;i<(nsize>>2);i++) {
-        i2=1+(i1=i+i);
-        i4=1+(i3=nsize-i1);
-        h1r=c1*(data[i1]+data[i3]);
-        h1i=c1*(data[i2]-data[i4]);
-        h2r= -c2*(data[i2]+data[i4]);
-        h2i=c2*(data[i1]-data[i3]);
-        data[i1]=h1r+wr*h2r-wi*h2i;
-        data[i2]=h1i+wr*h2i+wi*h2r;
-        data[i3]=h1r-wr*h2r+wi*h2i;
-        data[i4]= -h1i+wr*h2i+wi*h2r;
-        wr=(wtemp=wr)*wpr-wi*wpi+wr;
-        wi=wi*wpr+wtemp*wpi+wi;
-    }
-    if (isign == 1) {
-        data[0] = (h1r=data[0])+data[1];
-        data[1] = h1r-data[1];
-    } else {
-        data[0]=c1*((h1r=data[0])+data[1]);
-        data[1]=c1*(h1r-data[1]);
-        four1(data,-1,nsize);
+    else if(isign==-1){
+        fftw_complex *fftarray;
+        fftarray=(fftw_complex*) fftw_malloc(sizeof(fftw_complex) * (nsize/2+1));
+        format_transform(nsize,-1,fftarray, data);
+        double* invfft;
+        invfft=FFTtools::doInvFFT(nsize, (FFTWComplex*)fftarray);
+        for(int i=0;i<nsize;i++)
+            data[i]=invfft[i]*nsize/2;
+        free(fftarray);
     }
 }
 
-void Tools::four1(double *data, const int isign,int nsize) {
-    //int n,mmax,m,j,istep,i;
-    int nn,mmax,m,j,istep,i;
-    double wtemp,wr,wpr,wpi,wi,theta,tempr,tempi;
-
-    //int nn=nsize/2;
-    int n=nsize/2;
-
-    nn=n << 1;
-    j=1;
-    for (i=1;i<nn;i+=2) {
-        if (j > i) {
-            //SWAP(data[j-1],data[i-1]);
-            //SWAP(data[j],data[i]);
-            Exchange(data[j-1],data[i-1]);
-            Exchange(data[j],data[i]);
-        }
-        m=n;
-        while (m >= 2 && j > m) {
-            j -= m;
-            m >>= 1;
-        }
-        j += m;
-    }
-    mmax=2;
-    while (nn > mmax) {
-        istep=mmax << 1;
-        theta=isign*(6.28318530717959/mmax);
-        wtemp=sin(0.5*theta);
-        wpr = -2.0*wtemp*wtemp;
-        wpi=sin(theta);
-        wr=1.0;
-        wi=0.0;
-        for (m=1;m<mmax;m+=2) {
-            for (i=m;i<=nn;i+=istep) {
-                j=i+mmax;
-                tempr=wr*data[j-1]-wi*data[j];
-                tempi=wr*data[j]+wi*data[j-1];
-                data[j-1]=data[i-1]-tempr;
-                data[j]=data[i]-tempi;
-                data[i-1] += tempr;
-                data[i] += tempi;
+void Tools::format_transform(int nsize, int trdir, fftw_complex *out, double *data){
+    if(trdir==1){
+        for(int i=0;i<nsize;i++){
+            if(i%2){
+                data[i]=(-1)*out[i/2][i%2];
             }
-            wr=(wtemp=wr)*wpr-wi*wpi+wr;
-            wi=wi*wpr+wtemp*wpi+wi;
+            else{
+                data[i]=out[i/2][i%2];
+            }
         }
-        mmax=istep;
+        data[1]=out[nsize/2][0];
+    }else if(trdir==-1){
+        for(int i=2;i<nsize;i++){
+            if(i%2){
+                out[i/2][i%2]=(-1)*data[i];
+            }
+            else {
+                out[i/2][i%2]=data[i];
+            }
+        }
+        out[0][0]=data[0];
+        out[0][1]=0;
+        out[nsize/2][0]=data[1];
+        out[nsize/2][1]=0;
     }
 }
 

--- a/Tools.cc
+++ b/Tools.cc
@@ -122,6 +122,11 @@ void Tools::realft(double *data, const int isign, int nsize){
     * This function was specifically engineered by Yuchieh Ku
     * to emulate the interface of the numerical recipes "realft" function
     * <YUCHIEH WILL ADD MORE DOCUMENTATION HERE>
+    * This function has exactly the same input and output formats as the "realft" function in the numerical recipes. 
+    * Input array {f1,f2,f3....f_nsize}, after this fcn, it will become {F_0, F_N/2, F_1_r, F_1_c, F_2_r, F_2_c,...} (Forward). 
+    * isign: 1/-1 Forward/Inverse FFT.
+    * For forward FFT, complex conjugate is taken since isign convention is opposite in numerical recipes.
+    * Inverse FFT has a N/2 normalization factor.
     */
 
 

--- a/Tools.h
+++ b/Tools.h
@@ -8,6 +8,7 @@
 #include "TRandom3.h" 
 #include <iostream>
 #include <fstream>
+#include <fftw3.h>
 
 using namespace std;
 using std::string;
@@ -35,7 +36,7 @@ class Tools {
     static int Getifreq(double freq,double freq_low,double freq_high,int n);
     static void InterpolateComplex(double *array, const int n);
 
-    static void four1(double *data, const int isign,int nsize);
+    static void format_transform(int nsize, int trdr, fftw_complex *out, double *data);
     static void realft(double *data, const int isign, int nsize);
 
     static void SWAP(double &a, double &b) // swaps two numbers

--- a/log.txt
+++ b/log.txt
@@ -1604,3 +1604,7 @@ Boost is chosen to do the interpolation (instead of GSL, ROOT, etc.)
 because AraSim already has boost as a dependency, and boost has a nice interface
 to the sinc/Whittaker-Shannon method.
 as a dependency 
+=============================================================================
+2021/02/21 Yuchieh Ku
+Replaced the FFT function realft() in the Tools class. The previous realft() was from numerical recipes, it is replaced by a new function that uses FFTtools.h and fftw3.h. 
+Related documents in DocBD: http://ara.physics.wisc.edu/docs/0022/002291/001/FFT.pdf

--- a/log.txt
+++ b/log.txt
@@ -1607,4 +1607,5 @@ as a dependency
 =============================================================================
 2021/02/21 Yuchieh Ku
 Replaced the FFT function realft() in the Tools class. The previous realft() was from numerical recipes, it is replaced by a new function that uses FFTtools.h and fftw3.h. 
-Related documents in DocBD: http://ara.physics.wisc.edu/docs/0022/002291/001/FFT.pdf
+Related documents in DocBD: http://ara.physics.wisc.edu/docs/0022/002291/001/FFT.pdf, 
+and http://ara.physics.wisc.edu/docs/0023/002313/001/FFTupdate.pdf


### PR DESCRIPTION
This update to AraSim makes it so that the AraSim FFT routines are now based on FFTW through the FFTools package and libRootFftwWrapper (https://github.com/nichol77/libRootFftwWrapper).

Special care was taken to make sure that the data packing, etc. did not change in `realft`. So this operates a drop-in replacement.