### PR TITLE
Skipping the attenuation calculation when two Raystep positions are the same.

### DIFF
--- a/log.txt
+++ b/log.txt
@@ -1648,3 +1648,9 @@ for debugging.
 Replaced the FFT function realft() in the Tools class. The previous realft() was from numerical recipes, it is replaced by a new function that uses FFTtools.h and fftw3.h. 
 Related documents in DocBD: http://ara.physics.wisc.edu/docs/0022/002291/001/FFT.pdf, 
 and http://ara.physics.wisc.edu/docs/0023/002313/001/FFTupdate.pdf
+
+=============================================================================
+2021/03/31 Myoungchul Kim
+
+Skipping attenuation calculation when the distance between two RaySteps is 0.
+It prevents adding '-nan' into the IceAttenFactor and deleting the E-field array by '-nan'.


### PR DESCRIPTION
In the `NOFZ=0` (bulk ice) setting, (somehow) two Raysteps can be in the same coordinate.

It is causing [IceAttenFactor](https://github.com/ara-software/AraSim/blob/3f5463534b5c2390ed6c9bf70264163d2bfa117d/Report.cc#L456) to become a `-nan` and adding it into WF.

By simply skipping the calculation when two Raysteps are the same, It will prevent adding `-nan` into WF and crashing the simulation.

Details are in the [issues#50](https://github.com/ara-software/AraSim/issues/50)!