### PR TITLE
Real station option (DETECTOR=4) for Aeff mode (INTERACTION_MODE=0)

### DIFF
--- a/Primaries.cc
+++ b/Primaries.cc
@@ -2109,7 +2109,7 @@ double Interaction::PickNear_Sphere (IceModel *antarctica, Detector *detector, S
 
     double X, Y, Z;    // X,Y wrt detector core
     //calculate posnu's X, Y wrt detector core
-    if (detector->Get_mode() == 1 || detector->Get_mode() == 2 || detector->Get_mode() == 3) {   // detector mode is for ARA stations;
+    if (detector->Get_mode() == 1 || detector->Get_mode() == 2 || detector->Get_mode() == 3 || detector->Get_mode() == 4) {   // detector mode is for ARA stations;
       X = detector->params.core_x + transX;
       Y = detector->params.core_y + transY;
       Z = transZ;

--- a/log.txt
+++ b/log.txt
@@ -1693,3 +1693,12 @@ I left the Testbed mode completely alone.
 
 A detailed summary of how the new and updated version works is available
 on DocDB: https://aradocs.wipac.wisc.edu/cgi-bin/DocDB/ShowDocument?docid=2620
+
+==============================================================================
+2022/07/28 Myoungchul Kim
+
+When simulation sets the vertex position of each event, It needs to be added 10km in each XY coordinate to avoid the intersection of bins of the earth model.
+In Interaction::PickNear_Sphere, which is setting vertex positions, the 'adding 10 km' is only happening if DETECTOR setting is 1~3. 
+So, if we use DETECTOR=4, It will do nothing
+I added 'detector->Get_mode() == 4' option in the Interaction::PickNear_Sphere. 
+So that user can use effective area (INTERACTION_MODE=0) mode with deployed station mode (DETECTOR=4)


### PR DESCRIPTION
When simulation sets the vertex position of each event, It needs to be added 10km in each XY coordinate to avoid the intersection of bins of the earth model.
In [Interaction::PickNear_Sphere](https://github.com/ara-software/AraSim/blob/e054a6bc1969611ae4c44c3c82f07179b1e1bab8/Primaries.cc#L2074), which is setting vertex positions, the 'adding 10 km' is only happening if [DETECTOR setting is 1~3](https://github.com/ara-software/AraSim/blob/e054a6bc1969611ae4c44c3c82f07179b1e1bab8/Primaries.cc#L2112). So, if we use `DETECTOR=4`, It will do nothing
I added `detector->Get_mode() == 4` option in the [if condition](https://github.com/ara-software/AraSim/blob/e054a6bc1969611ae4c44c3c82f07179b1e1bab8/Primaries.cc#L2112) like [Interaction::PickNear_Cylinder](https://github.com/ara-software/AraSim/blob/e054a6bc1969611ae4c44c3c82f07179b1e1bab8/Primaries.cc#L1961). So that user can use effective area mode with deployed station mode