### PR TITLE
Add support for A4 and A5 geometry

### DIFF
--- a/Detector.cc
+++ b/Detector.cc
@@ -34,71 +34,48 @@ Detector::Detector() {
 }
 
 
-Detector::Detector(Settings *settings1, IceModel *icesurface, string setupfile) {
-    //Detector::Detector(int mode, IceModel *icesurface) {
-    cout << "good" << endl;
-    
-    // set freq_forfft for later use
-    //
-    
-    // set freq_forfft array
-    // same with icemc anita class initialization function
-    
-    
-    double freqstep=1./(double)(settings1->NFOUR/2)/(settings1->TIMESTEP);
-    
-    NFOUR = settings1->NFOUR;
-    TIMESTEP = settings1->TIMESTEP;
-    
-    NoiseFig_numCh=16;
+Detector::Detector(Settings * settings1, IceModel * icesurface, string setupfile) {
 
-    //for (int i=0;i<HALFNFOUR/2;i++) {
-    for (int i=0;i<settings1->NFOUR/4;i++) {
-        //--------------------------------------------------
-        // freq_forfft[2*i]=(double)i*freqstep;
-        // freq_forfft[2*i+1]=(double)i*freqstep;
-        //-------------------------------------------------- 
-        freq_forfft.push_back( (double)i*freqstep );    // even numbers
-        freq_forfft.push_back( (double)i*freqstep );    // odd numbers
-        
+
+    double freqstep = 1. / (double)(settings1 -> NFOUR / 2) / (settings1 -> TIMESTEP);
+
+    NFOUR = settings1 -> NFOUR;
+    TIMESTEP = settings1 -> TIMESTEP;
+
+    NoiseFig_numCh = 16;
+
+    for (int i = 0; i < settings1 -> NFOUR / 4; i++) {
+
+        freq_forfft.push_back((double) i * freqstep); // even numbers
+        freq_forfft.push_back((double) i * freqstep); // odd numbers
+
     }
-    for (int i=settings1->NFOUR/4;i<settings1->NFOUR/2;i++) {
-        //--------------------------------------------------
-        // freq_forfft[2*i]=(double)i*freqstep;
-        // freq_forfft[2*i+1]=(double)i*freqstep;
-        //-------------------------------------------------- 
-        freq_forfft.push_back( (double)i*freqstep );    // even numbers
-        freq_forfft.push_back( (double)i*freqstep );    // odd numbers
-        
+    for (int i = settings1 -> NFOUR / 4; i < settings1 -> NFOUR / 2; i++) {
+        freq_forfft.push_back((double) i * freqstep); // even numbers
+        freq_forfft.push_back((double) i * freqstep); // odd numbers
+
     }
     // end of settings freq_forfft
-    
-    
-    
-    
+
     //set mode ex) mode 0 = testbed,
     // mode 1 = ARA_1
     // mode 2 = ARA_2
     // mode 3 = ARA_37
-    int mode = settings1->DETECTOR;
+    int mode = settings1 -> DETECTOR;
     Detector_mode = mode;
-    
+
     int string_id = -1;
-    //    int string_id = 0;
     int antenna_id = 0;
-    
-    
-    //    Parameters params;
-    //    vector <Antenna_string> strings;
+
     ARA_station temp_station;
     Antenna_string temp;
     Antenna_string temp_string;
     Antenna temp_antenna;
     Surface_antenna temp_surface;
-    
+
     params.number_of_strings = 0;
     params.number_of_antennas = 0;
-    
+
     //initialize few params values.
     params.freq_step = 60;
     params.ang_step = 2664;
@@ -106,882 +83,743 @@ Detector::Detector(Settings *settings1, IceModel *icesurface, string setupfile) 
     params.freq_init = 83.333;
     params.DeployedStations = 4;
     //end initialize
-    
+
     //Parameters to use if using Arianna_WIPLD_hpol.dat
-    
-    if (settings1->ANTENNA_MODE == 2){
-      params.freq_step = 238;//60
-      params.ang_step = 2664;//2664;
-      params.freq_width = 5; //16.667;
-      params.freq_init = 15;//83.333;
-      params.DeployedStations = 4;
+
+    if (settings1 -> ANTENNA_MODE == 2) {
+        params.freq_step = 238; //60
+        params.ang_step = 2664; //2664;
+        params.freq_width = 5; //16.667;
+        params.freq_init = 15; //83.333;
+        params.DeployedStations = 4;
     }
-    
+
     //copy freq_width, freq_init in params to Detector freq_width, freq_init
     freq_step = params.freq_step;
     ang_step = params.ang_step;
     freq_width = params.freq_width;
     freq_init = params.freq_init;
     //end copy
-    
-    
+
     string testbed_file = "testbed_info.txt";
-//--------------------------------------------------
-//     string ARA_N_file = "ARA_N_info.txt";
-//     string ARA37_file = "ARA37_info.txt";
-//-------------------------------------------------- 
     string ARA_N_file = setupfile;
     string ARA37_file = setupfile;
-    
+
     string line, label;
 
     // setup installed station information
     // setup actual installed staion information regardless of what DETECTOR mode is in use
     SetupInstalledStations();
-    
-    //    IceModel *icesurface = new IceModel;
-    //cout<<"Ice surface at 0,0 : "<<icesurface->Geoid(0.)<<endl;
-    
-    
-    ////////////////////////////////////////////////////////////////////////////////////    
-    
+
+
     if (mode == 0) {
-        cout<<"\n\tDector mode 0 : testbed"<<endl;
-        ifstream testbed( testbed_file.c_str() );
-        cout<<"We use "<<testbed_file.c_str()<<" as antenna info."<<endl;
-        
-        
-        if ( testbed.is_open() ) {
-            while (testbed.good() ) {
-                getline (testbed, line);
-                
-                if (line[0] != "/"[0]) {
-                    label = line.substr(0, line.find_first_of("=") );
-                    
+        cout << "\n\tDector mode 0 : testbed" << endl;
+        ifstream testbed(testbed_file.c_str());
+        cout << "We use " << testbed_file.c_str() << " as antenna info." << endl;
+
+        if (testbed.is_open()) {
+            while (testbed.good()) {
+                getline(testbed, line);
+
+                if (line[0] != "/" [0]) {
+                    label = line.substr(0, line.find_first_of("="));
+
                     if (label == "number_of_strings") {
-                        params.number_of_strings = atoi( line.substr( line.find_first_of("=") + 1).c_str() );
-                        for (int i=0; i<(int) params.number_of_strings; i++) {
+                        params.number_of_strings = atoi(line.substr(line.find_first_of("=") + 1).c_str());
+                        for (int i = 0; i < (int) params.number_of_strings; i++) {
                             strings.push_back(temp);
                         }
-                        cout<<"read numner_of_strings"<<endl;
+                        cout << "read numner_of_strings" << endl;
                         //                        Parameters.number_of_strings = atoi( line.substr( line.find_first_of("=") + 1).c_str() );
-                    }
-                    else if (label == "antenna_string") {
+                    } else if (label == "antenna_string") {
                         string_id++;
                         antenna_id = 0;
-                        cout<<"read antenna_string"<<endl;
+                        cout << "read antenna_string" << endl;
                         //                        if (string_id + 1 >= params.number_of_strings) {
                         //                            cout<<"Error! Too many strings!"<<endl;
                         //                        }
-                    }
-                    else if (label == "x") {
+                    } else if (label == "x") {
                         //strings[string_id].x = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        strings[string_id].SetX( atof( line.substr( line.find_first_of("=") + 1).c_str() ) );
-                        cout<<"read x : "<<(double)strings[string_id].GetX()<<" string_id : "<<string_id<<endl;
-                    }
-                    else if (label == "y") {
+                        strings[string_id].SetX(atof(line.substr(line.find_first_of("=") + 1).c_str()));
+                        cout << "read x : " << (double) strings[string_id].GetX() << " string_id : " << string_id << endl;
+                    } else if (label == "y") {
                         //strings[string_id].y = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        strings[string_id].SetY( atof( line.substr( line.find_first_of("=") + 1).c_str() ) );
-                        cout<<"read y : "<<(double)strings[string_id].GetY()<<" string_id : "<<string_id<<endl;
-                    }
-                    else if (label == "z") {
+                        strings[string_id].SetY(atof(line.substr(line.find_first_of("=") + 1).c_str()));
+                        cout << "read y : " << (double) strings[string_id].GetY() << " string_id : " << string_id << endl;
+                    } else if (label == "z") {
                         strings[string_id].antennas.push_back(temp_antenna);
                         //strings[string_id].antennas[antenna_id].z = atof( line.substr( line.find_first_of("=") + 1, line.find_first_of(",") ).c_str() );
-                        strings[string_id].antennas[antenna_id].SetZ( atof( line.substr( line.find_first_of("=") + 1, line.find_first_of(",") ).c_str() ) );
-                        strings[string_id].antennas[antenna_id].type = atoi( line.substr( line.find_first_of(",") + 1).c_str() );
-                        cout<<"read z : "<<(double)strings[string_id].antennas[antenna_id].GetZ()<<" string_id : "<<string_id<<" antenna_id : "<<antenna_id<<" type : "<<(int)strings[string_id].antennas[antenna_id].type<<endl;
+                        strings[string_id].antennas[antenna_id].SetZ(atof(line.substr(line.find_first_of("=") + 1, line.find_first_of(",")).c_str()));
+                        strings[string_id].antennas[antenna_id].type = atoi(line.substr(line.find_first_of(",") + 1).c_str());
+                        cout << "read z : " << (double) strings[string_id].antennas[antenna_id].GetZ() << " string_id : " << string_id << " antenna_id : " << antenna_id << " type : " << (int) strings[string_id].antennas[antenna_id].type << endl;
                         antenna_id++;
                         params.number_of_antennas++;
                         //                        Parameters.number_of_antennas++;
                     }
-                    
-                    
+
                 }
             }
             testbed.close();
-        }
-        
-        else {
-            cout<<"Unable to open antenna array file !"<<endl;
+        } else {
+            cout << "Unable to open antenna array file !" << endl;
             //            return 1;
         }
-        
-        
+
         // testbed version of FlattoEarth_ARA 
         // strings and antennas on the strings use geoid surface!
-        double Dist = 0.;   //for sqrt(x^2 + y^2)
-        double R1 = icesurface->Surface(0.,0.); // from core of earth to surface at theta, phi = 0.
+        double Dist = 0.; //for sqrt(x^2 + y^2)
+        double R1 = icesurface -> Surface(0., 0.); // from core of earth to surface at theta, phi = 0.
         double theta_tmp;
         double phi_tmp;
-        
+
         // set same theta, phi to all antennas in same string
-        for (int i=0; i<params.number_of_strings; i++) {
-            
-            Dist = sqrt( pow(strings[i].GetX(),2) + pow(strings[i].GetY(),2) );
-            theta_tmp = Dist/R1;    // assume R1 is constant (which is not)
-            phi_tmp = atan2(strings[i].GetY(),strings[i].GetX());
-            
-            if (phi_tmp<0.) phi_tmp += 2.*PI;
-            
+        for (int i = 0; i < params.number_of_strings; i++) {
+
+            Dist = sqrt(pow(strings[i].GetX(), 2) + pow(strings[i].GetY(), 2));
+            theta_tmp = Dist / R1; // assume R1 is constant (which is not)
+            phi_tmp = atan2(strings[i].GetY(), strings[i].GetX());
+
+            if (phi_tmp < 0.) phi_tmp += 2. * PI;
+
             // set theta, phi for strings.
             strings[i].SetThetaPhi(theta_tmp, phi_tmp);
             //set R for strings.
-            strings[i].SetR( icesurface->Surface( strings[i].Lon(), strings[i].Lat()) );
-            
-            cout<<"R, Theta, Phi : "<<strings[i].R()<<" "<<strings[i].Theta()<<" "<<strings[i].Phi()<<endl;
-            
+            strings[i].SetR(icesurface -> Surface(strings[i].Lon(), strings[i].Lat()));
+
+            cout << "R, Theta, Phi : " << strings[i].R() << " " << strings[i].Theta() << " " << strings[i].Phi() << endl;
+
             // set antennas r, theta, phi
-            for (int j=0; j<antenna_id; j++) {
-                strings[i].antennas[j].SetRThetaPhi( strings[i].R() + strings[i].antennas[j].GetZ() , strings[i].Theta(), strings[i].Phi() );
+            for (int j = 0; j < antenna_id; j++) {
+                strings[i].antennas[j].SetRThetaPhi(strings[i].R() + strings[i].antennas[j].GetZ(), strings[i].Theta(), strings[i].Phi());
             }
         }
-        
-        
-        
-        
-        
-        
-    }
-    
+
+    } // if mode == 0 
+
     /////////////////////////////////////////////////////////////////////////////
-    
-    
-    
-    
     else if (mode == 1) {
-//        cout<<"\n\tDector mode 1 : Specific number of stations (less than 7 stations) !"<<endl;
-        ifstream ARA_N( ARA_N_file.c_str() );
-//        cout<<"We use "<<ARA_N_file.c_str()<<" as antenna info."<<endl;
-        
-        
+        //        cout<<"\n\tDector mode 1 : Specific number of stations (less than 7 stations) !"<<endl;
+        ifstream ARA_N(ARA_N_file.c_str());
+        //        cout<<"We use "<<ARA_N_file.c_str()<<" as antenna info."<<endl;
+
         // initialize info
         params.number_of_stations = 1;
-        params.number_of_strings_station = 4;   // ARA-1 has 4 strings
+        params.number_of_strings_station = 4; // ARA-1 has 4 strings
         params.number_of_antennas_string = 4; // 4 antennas on each strings
         params.number_of_surfaces_station = 4;
-        
-	
 
         //double core_x = 0.; 
         //double core_y = 0.;
-        params.core_x = 10000.; 
+        params.core_x = 10000.;
         params.core_y = 10000.;
-        double R_string = 10.;  // all units are in meter
+        double R_string = 10.; // all units are in meter
         double R_surface = 60.;
         double z_max = 200.;
         double z_btw = 10.;
         double z_btw_array[6]; // assume there will be less than 6 bore hole antennas at each string
-	// these z_btw array will be used when settings->BH_ANT_SEP_DIST_ON=1 case
-        for (int i=0; i<6; i++) {
-            if (i==0) z_btw_array[i] = 0.;
+        // these z_btw array will be used when settings->BH_ANT_SEP_DIST_ON=1 case
+        for (int i = 0; i < 6; i++) {
+            if (i == 0) z_btw_array[i] = 0.;
             //else z_btw_array[i] = z_btw;
-            else if (i==1) z_btw_array[i] = 2.;
-            else if (i==2) z_btw_array[i] = 15.;
-            else if (i==3) z_btw_array[i] = 2.;
+            else if (i == 1) z_btw_array[i] = 2.;
+            else if (i == 2) z_btw_array[i] = 15.;
+            else if (i == 3) z_btw_array[i] = 2.;
             else z_btw_array[i] = z_btw;
         }
         double z_btw_total;
-        params.stations_per_side = 4;       // total 37 stations
-        params.station_spacing = 2000.;     // 2km spacing
-        params.antenna_orientation = 0;     // all antenna facing x
-        params.bore_hole_antenna_layout = settings1->BORE_HOLE_ANTENNA_LAYOUT;
+        params.stations_per_side = 4; // total 37 stations
+        params.station_spacing = 2000.; // 2km spacing
+        params.antenna_orientation = 0; // all antenna facing x
+        params.bore_hole_antenna_layout = settings1 -> BORE_HOLE_ANTENNA_LAYOUT;
         // finish initialization
         //
-        
-        
-        
-        
-        
+
         // Read new parameters if there are...
-        if ( ARA_N.is_open() ) {
-            while (ARA_N.good() ) {
-                getline (ARA_N, line);
-                
-                if (line[0] != "/"[0]) {
-                    label = line.substr(0, line.find_first_of("=") );
-                    
+        if (ARA_N.is_open()) {
+            while (ARA_N.good()) {
+                getline(ARA_N, line);
+
+                if (line[0] != "/" [0]) {
+                    label = line.substr(0, line.find_first_of("="));
+
                     if (label == "core_x") {
-                        params.core_x = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read core_x"<<endl;
-                    }
-                    else if (label == "core_y") {
-                        params.core_y = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read core_y"<<endl;
-                    }
-                    else if (label == "R_string") {
-                        R_string = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read R_string"<<endl;
-                    }
-                    else if (label == "R_surface") {
-                        R_surface = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read R_surface"<<endl;
-                    }
-                    else if (label == "z_max") {
-                        z_max = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_max"<<endl;
-                    }
-                    else if (label == "z_btw") {
-                        z_btw = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_btw"<<endl;
-                    }
-                    else if (label == "z_btw01") {
-                        z_btw_array[1] = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_btw bh ant0 and ant1"<<endl;
-                    }
-                    else if (label == "z_btw12") {
-                        z_btw_array[2] = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_btw bh ant1 and ant2"<<endl;
-                    }
-                    else if (label == "z_btw23") {
-                        z_btw_array[3] = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_btw bh ant2 and ant3"<<endl;
-                    }
-                    else if (label == "z_btw34") {
-                        z_btw_array[4] = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_btw bh ant3 and ant4"<<endl;
-                    }
-                    else if (label == "z_btw45") {
-                        z_btw_array[5] = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_btw bh ant4 and ant5"<<endl;
-                    }
-                    else if (label == "number_of_stations") {
-                        params.number_of_stations = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read stations_per_side"<<endl;
-                    }
-                    else if (label == "station_spacing") {
-                        params.station_spacing = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read station_spacting"<<endl;
-                    }
-                    else if (label == "antenna_orientation") {
-                        params.antenna_orientation = atoi( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read antenna_orientation"<<endl;
-                    }
-                    else if (label == "number_of_strings_station") {
-                        params.number_of_strings_station = atoi( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read number of strings"<<endl;
-                    }
-                    else if (label == "number_of_antennas_string") {
-                        params.number_of_antennas_string = atoi( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read number of antennas per string"<<endl;
+                        params.core_x = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read core_x" << endl;
+                    } else if (label == "core_y") {
+                        params.core_y = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read core_y" << endl;
+                    } else if (label == "R_string") {
+                        R_string = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read R_string" << endl;
+                    } else if (label == "R_surface") {
+                        R_surface = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read R_surface" << endl;
+                    } else if (label == "z_max") {
+                        z_max = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_max" << endl;
+                    } else if (label == "z_btw") {
+                        z_btw = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_btw" << endl;
+                    } else if (label == "z_btw01") {
+                        z_btw_array[1] = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_btw bh ant0 and ant1" << endl;
+                    } else if (label == "z_btw12") {
+                        z_btw_array[2] = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_btw bh ant1 and ant2" << endl;
+                    } else if (label == "z_btw23") {
+                        z_btw_array[3] = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_btw bh ant2 and ant3" << endl;
+                    } else if (label == "z_btw34") {
+                        z_btw_array[4] = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_btw bh ant3 and ant4" << endl;
+                    } else if (label == "z_btw45") {
+                        z_btw_array[5] = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_btw bh ant4 and ant5" << endl;
+                    } else if (label == "number_of_stations") {
+                        params.number_of_stations = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read stations_per_side" << endl;
+                    } else if (label == "station_spacing") {
+                        params.station_spacing = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read station_spacting" << endl;
+                    } else if (label == "antenna_orientation") {
+                        params.antenna_orientation = atoi(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read antenna_orientation" << endl;
+                    } else if (label == "number_of_strings_station") {
+                        params.number_of_strings_station = atoi(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read number of strings" << endl;
+                    } else if (label == "number_of_antennas_string") {
+                        params.number_of_antennas_string = atoi(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read number of antennas per string" << endl;
                     }
                 }
             }
             ARA_N.close();
         }
         // finished reading new parameters
-        
-        
-        
+
         // set number of antennas in a string
         if (params.bore_hole_antenna_layout == 0) { // VHVH layout
             params.number_of_antennas_string = 4;
-        }
-        else if (params.bore_hole_antenna_layout == 1) { // VHV layout
+        } else if (params.bore_hole_antenna_layout == 1) { // VHV layout
             params.number_of_antennas_string = 3;
-        }
-        else if (params.bore_hole_antenna_layout == 2) { // VHVV layout
+        } else if (params.bore_hole_antenna_layout == 2) { // VHVV layout
             params.number_of_antennas_string = 4;
-        }
-        else if (params.bore_hole_antenna_layout == 3) { // VHHH layout
+        } else if (params.bore_hole_antenna_layout == 3) { // VHHH layout
             params.number_of_antennas_string = 4;
-        }
-        else if (params.bore_hole_antenna_layout == 4) { // VHH layout
+        } else if (params.bore_hole_antenna_layout == 4) { // VHH layout
             params.number_of_antennas_string = 3;
-        }
-        else if (params.bore_hole_antenna_layout == 5) { // VVVV layout
+        } else if (params.bore_hole_antenna_layout == 5) { // VVVV layout
             params.number_of_antennas_string = 4;
-        }
-        else if (params.bore_hole_antenna_layout == 6) { // VV layout
+        } else if (params.bore_hole_antenna_layout == 6) { // VV layout
             params.number_of_antennas_string = 2;
-        }
-	else if (params.bore_hole_antenna_layout == 7) { // V layout
+        } else if (params.bore_hole_antenna_layout == 7) { // V layout
             params.number_of_antennas_string = 1;
         }
 
-        
-        
-        
-        
         //
         // caculate number of stations, strings, antennas 
         params.number_of_strings = params.number_of_stations * params.number_of_strings_station;
         params.number_of_antennas = params.number_of_strings * params.number_of_antennas_string;
         //
         //
-        
-        
-        
+
         //
         // prepare vectors
-        for (int i=0; i<params.number_of_stations; i++) {
+        for (int i = 0; i < params.number_of_stations; i++) {
             stations.push_back(temp_station);
-            
-            for (int j=0; j<params.number_of_surfaces_station; j++) {
+
+            for (int j = 0; j < params.number_of_surfaces_station; j++) {
                 stations[i].surfaces.push_back(temp_surface);
             }
-            
-            for (int k=0; k<params.number_of_strings_station; k++) {
+
+            for (int k = 0; k < params.number_of_strings_station; k++) {
                 stations[i].strings.push_back(temp_string);
-                
-                for (int l=0; l<params.number_of_antennas_string; l++) {
+
+                for (int l = 0; l < params.number_of_antennas_string; l++) {
                     stations[i].strings[k].antennas.push_back(temp_antenna);
                 }
-                
+
             }
-            
-            
+
         }
         // end prepare vectors
         //
-        
-        
-        
-        
-        
+
         //
         // for ARA-37 (or more than 1 station case), need code for setting position for all 37 stations here!
         //
         int station_count = 0;
-        
+
         int side_step;
 
-        double next_dir = PI*2./3;
+        double next_dir = PI * 2. / 3;
 
-        for (int istation = 0; istation < (int)params.number_of_stations; istation++) {
-	  stations[istation].StationID=istation;
-	
-            if (station_count < (int)params.number_of_stations - 1) {
+        for (int istation = 0; istation < (int) params.number_of_stations; istation++) {
+            stations[istation].StationID = istation;
 
+            if (station_count < (int) params.number_of_stations - 1) {
 
-                if ( station_count < 6 ) { // first layer
-                    stations[station_count].SetX( params.core_x + (double)params.station_spacing * cos( (PI/3.) * (double)station_count ) );
-                    stations[station_count].SetY( params.core_y + (double)params.station_spacing * sin( (PI/3.) * (double)station_count ) );
-                }
-                else if ( station_count < 18 ) { // second layer
+                if (station_count < 6) { // first layer
+                    stations[station_count].SetX(params.core_x + (double) params.station_spacing * cos((PI / 3.) * (double) station_count));
+                    stations[station_count].SetY(params.core_y + (double) params.station_spacing * sin((PI / 3.) * (double) station_count));
+                } else if (station_count < 18) { // second layer
 
                     // if the first outter layer station
-                    if ( station_count == 6 ) {
+                    if (station_count == 6) {
                         side_step = 2;
-                        stations[station_count].SetX( params.core_x + (double)params.station_spacing * 2. );
-                        stations[station_count].SetY( params.core_y );
+                        stations[station_count].SetX(params.core_x + (double) params.station_spacing * 2.);
+                        stations[station_count].SetY(params.core_y);
                     }
                     // after first station
-                    else { 
-                        if ( side_step > 0 ) {
-                            stations[station_count].SetX( stations[station_count-1].GetX() + (double)params.station_spacing * cos(next_dir) );
-                            stations[station_count].SetY( stations[station_count-1].GetY() + (double)params.station_spacing * sin(next_dir) );
+                    else {
+                        if (side_step > 0) {
+                            stations[station_count].SetX(stations[station_count - 1].GetX() + (double) params.station_spacing * cos(next_dir));
+                            stations[station_count].SetY(stations[station_count - 1].GetY() + (double) params.station_spacing * sin(next_dir));
                             side_step--;
-                        }
-                        else {
+                        } else {
                             side_step = 1;
-                            next_dir+=PI/3.; // rotate
-                            stations[station_count].SetX( stations[station_count-1].GetX() + (double)params.station_spacing * cos(next_dir) );
-                            stations[station_count].SetY( stations[station_count-1].GetY() + (double)params.station_spacing * sin(next_dir) );
+                            next_dir += PI / 3.; // rotate
+                            stations[station_count].SetX(stations[station_count - 1].GetX() + (double) params.station_spacing * cos(next_dir));
+                            stations[station_count].SetY(stations[station_count - 1].GetY() + (double) params.station_spacing * sin(next_dir));
                         }
                     }
-                }
-                else if ( station_count < 36 ) { // third layer
+                } else if (station_count < 36) { // third layer
 
                     // if the first outter layer station
-                    if ( station_count == 6 ) {
+                    if (station_count == 6) {
                         side_step = 3;
-                        stations[station_count].SetX( params.core_x + (double)params.station_spacing * 3. );
-                        stations[station_count].SetY( params.core_y );
+                        stations[station_count].SetX(params.core_x + (double) params.station_spacing * 3.);
+                        stations[station_count].SetY(params.core_y);
                     }
                     // after first station
-                    else { 
-                        if ( side_step > 0 ) {
-                            stations[station_count].SetX( stations[station_count-1].GetX() + (double)params.station_spacing * cos(next_dir) );
-                            stations[station_count].SetY( stations[station_count-1].GetY() + (double)params.station_spacing * sin(next_dir) );
+                    else {
+                        if (side_step > 0) {
+                            stations[station_count].SetX(stations[station_count - 1].GetX() + (double) params.station_spacing * cos(next_dir));
+                            stations[station_count].SetY(stations[station_count - 1].GetY() + (double) params.station_spacing * sin(next_dir));
                             side_step--;
-                        }
-                        else {
+                        } else {
                             side_step = 2;
-                            next_dir+=PI/3.; // rotate
-                            stations[station_count].SetX( stations[station_count-1].GetX() + (double)params.station_spacing * cos(next_dir) );
-                            stations[station_count].SetY( stations[station_count-1].GetY() + (double)params.station_spacing * sin(next_dir) );
+                            next_dir += PI / 3.; // rotate
+                            stations[station_count].SetX(stations[station_count - 1].GetX() + (double) params.station_spacing * cos(next_dir));
+                            stations[station_count].SetY(stations[station_count - 1].GetY() + (double) params.station_spacing * sin(next_dir));
                         }
                     }
 
                 }
 
                 station_count++;
-            }
-            else if (station_count < (int)params.number_of_stations) {
+            } else if (station_count < (int) params.number_of_stations) {
                 //stations[station_count].x = core_x;
                 //stations[station_count].y = core_y;
-                stations[station_count].SetX( params.core_x );
-                stations[station_count].SetY( params.core_y );
+                stations[station_count].SetX(params.core_x);
+                stations[station_count].SetY(params.core_y);
                 station_count++;
-            }
-            else {
-                cout<<"\n\tError, too many stations !"<<endl;
+            } else {
+                cout << "\n\tError, too many stations !" << endl;
             }
         }
         // finished setting all stations' position
-        
 
-        
-//        cout<<"total station_count : "<<station_count<<endl;
-        if (station_count != (int)params.number_of_stations) cout<<"\n\tError, station number not match !"<<endl;       
-        
+        //        cout<<"total station_count : "<<station_count<<endl;
+        if (station_count != (int) params.number_of_stations) cout << "\n\tError, station number not match !" << endl;
+
         //
         // set antenna values from parameters
         // set station positions
-        if (settings1->READGEOM == 0) { // use idealized geometry
+        if (settings1 -> READGEOM == 0) { // use idealized geometry
 
-            for (int i=0; i<params.number_of_stations; i++) {
-                
+            for (int i = 0; i < params.number_of_stations; i++) {
+
                 //
                 // set string postions based on station position
-                stations[i].strings[0].SetX( stations[i].GetX() - (R_string * cos(PI/4.)) );
-                stations[i].strings[0].SetY( stations[i].GetY() + (R_string * sin(PI/4.)) );
-                
-                stations[i].strings[1].SetX( stations[i].GetX() + (R_string * cos(PI/4.)) );
-                stations[i].strings[1].SetY( stations[i].GetY() + (R_string * sin(PI/4.)) );
-                
-                stations[i].strings[2].SetX( stations[i].GetX() - (R_string * cos(PI/4.)) );
-                stations[i].strings[2].SetY( stations[i].GetY() - (R_string * sin(PI/4.)) );
-                
-                stations[i].strings[3].SetX( stations[i].GetX() + (R_string * cos(PI/4.)) );
-                stations[i].strings[3].SetY( stations[i].GetY() - (R_string * sin(PI/4.)) );
-                
-                
+                stations[i].strings[0].SetX(stations[i].GetX() - (R_string * cos(PI / 4.)));
+                stations[i].strings[0].SetY(stations[i].GetY() + (R_string * sin(PI / 4.)));
+
+                stations[i].strings[1].SetX(stations[i].GetX() + (R_string * cos(PI / 4.)));
+                stations[i].strings[1].SetY(stations[i].GetY() + (R_string * sin(PI / 4.)));
+
+                stations[i].strings[2].SetX(stations[i].GetX() - (R_string * cos(PI / 4.)));
+                stations[i].strings[2].SetY(stations[i].GetY() - (R_string * sin(PI / 4.)));
+
+                stations[i].strings[3].SetX(stations[i].GetX() + (R_string * cos(PI / 4.)));
+                stations[i].strings[3].SetY(stations[i].GetY() - (R_string * sin(PI / 4.)));
+
                 //
                 // set antenna postions in borehole
                 // and set type (h or v pol antenna) and set orientation (facing x or y)
-                if ( params.bore_hole_antenna_layout == 0 || params.bore_hole_antenna_layout == 1) {
-                    
-                    for (int j=0; j<params.number_of_strings_station; j++) {
-                        for (int k=0; k<params.number_of_antennas_string; k++) {
+                if (params.bore_hole_antenna_layout == 0 || params.bore_hole_antenna_layout == 1) {
 
-                            if (settings1->BH_ANT_SEP_DIST_ON==0) 
-                            stations[i].strings[j].antennas[k].SetZ( -z_max + z_btw*k );
+                    for (int j = 0; j < params.number_of_strings_station; j++) {
+                        for (int k = 0; k < params.number_of_antennas_string; k++) {
 
-                            else if (settings1->BH_ANT_SEP_DIST_ON==1) {
+                            if (settings1 -> BH_ANT_SEP_DIST_ON == 0)
+                                stations[i].strings[j].antennas[k].SetZ(-z_max + z_btw * k);
+
+                            else if (settings1 -> BH_ANT_SEP_DIST_ON == 1) {
                                 z_btw_total = 0.;
-                                for (int l=0; l<k+1; l++) {
+                                for (int l = 0; l < k + 1; l++) {
                                     z_btw_total += z_btw_array[l];
                                 }
-                                stations[i].strings[j].antennas[k].SetZ( -z_max + z_btw_total );
+                                stations[i].strings[j].antennas[k].SetZ(-z_max + z_btw_total);
                             }
-                            
-                            if (k%2 == 0) {
-                                stations[i].strings[j].antennas[k].type = 0;   // v-pol
+
+                            if (k % 2 == 0) {
+                                stations[i].strings[j].antennas[k].type = 0; // v-pol
+                            } else {
+                                stations[i].strings[j].antennas[k].type = 1; // h-pol
                             }
-                            else {
-                                stations[i].strings[j].antennas[k].type = 1;   // h-pol
-                            }
-                            
-                            if ( params.antenna_orientation == 0 ) {    // all borehole antennas facing same x
+
+                            if (params.antenna_orientation == 0) { // all borehole antennas facing same x
                                 stations[i].strings[j].antennas[k].orient = 0;
-                            }
-                            else if ( params.antenna_orientation == 1 ) {   // borehole antennas one next facing different way
-                                if ( j==0||j==3 ) {
-                                    if ( k==0||k==1 ) {
+                            } else if (params.antenna_orientation == 1) { // borehole antennas one next facing different way
+                                if (j == 0 || j == 3) {
+                                    if (k == 0 || k == 1) {
                                         stations[i].strings[j].antennas[k].orient = 0;
-                                    }
-                                    else {
+                                    } else {
                                         stations[i].strings[j].antennas[k].orient = 1;
                                     }
-                                }
-                                else {
-                                    if ( k==0||k==1 ) {
+                                } else {
+                                    if (k == 0 || k == 1) {
                                         stations[i].strings[j].antennas[k].orient = 1;
-                                    }
-                                    else {
+                                    } else {
                                         stations[i].strings[j].antennas[k].orient = 0;
                                     }
                                 }
-                                
-                            }// end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
+
+                            } // end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
                         }
                     }
-                    
+
                 } // end if bore hole antenna layout = 0 or 1 (where VHVH way but different numbers)
-                
-                
-                else if ( params.bore_hole_antenna_layout == 2) {   // it's V-H-V-V
-                    
-                    for (int j=0; j<params.number_of_strings_station; j++) {
-                        for (int k=0; k<params.number_of_antennas_string; k++) {
+                else if (params.bore_hole_antenna_layout == 2) { // it's V-H-V-V
 
-                            if (settings1->BH_ANT_SEP_DIST_ON==0) 
-                            stations[i].strings[j].antennas[k].SetZ( -z_max + z_btw*k );
+                    for (int j = 0; j < params.number_of_strings_station; j++) {
+                        for (int k = 0; k < params.number_of_antennas_string; k++) {
 
-                            else if (settings1->BH_ANT_SEP_DIST_ON==1) {
+                            if (settings1 -> BH_ANT_SEP_DIST_ON == 0)
+                                stations[i].strings[j].antennas[k].SetZ(-z_max + z_btw * k);
+
+                            else if (settings1 -> BH_ANT_SEP_DIST_ON == 1) {
                                 z_btw_total = 0.;
-                                for (int l=0; l<k+1; l++) {
+                                for (int l = 0; l < k + 1; l++) {
                                     z_btw_total += z_btw_array[l];
                                 }
-                                stations[i].strings[j].antennas[k].SetZ( -z_max + z_btw_total );
+                                stations[i].strings[j].antennas[k].SetZ(-z_max + z_btw_total);
                             }
-                            
-                            if (k == 1) {   // only the second antenna is H pol
-                                stations[i].strings[j].antennas[k].type = 1;   // h-pol
+
+                            if (k == 1) { // only the second antenna is H pol
+                                stations[i].strings[j].antennas[k].type = 1; // h-pol
+                            } else { // other antennas are V pol
+                                stations[i].strings[j].antennas[k].type = 0; // v-pol
                             }
-                            else {  // other antennas are V pol
-                                stations[i].strings[j].antennas[k].type = 0;   // v-pol
-                            }
-                            
-                            if ( params.antenna_orientation == 0 ) {    // all borehole antennas facing same x
+
+                            if (params.antenna_orientation == 0) { // all borehole antennas facing same x
                                 stations[i].strings[j].antennas[k].orient = 0;
-                            }
-                            else if ( params.antenna_orientation == 1 ) {   // borehole antennas one next facing different way
-                                if ( j==0||j==3 ) {
-                                    if ( k==0||k==1 ) {
+                            } else if (params.antenna_orientation == 1) { // borehole antennas one next facing different way
+                                if (j == 0 || j == 3) {
+                                    if (k == 0 || k == 1) {
                                         stations[i].strings[j].antennas[k].orient = 0;
-                                    }
-                                    else {
+                                    } else {
                                         stations[i].strings[j].antennas[k].orient = 1;
                                     }
-                                }
-                                else {
-                                    if ( k==0||k==1 ) {
+                                } else {
+                                    if (k == 0 || k == 1) {
                                         stations[i].strings[j].antennas[k].orient = 1;
-                                    }
-                                    else {
+                                    } else {
                                         stations[i].strings[j].antennas[k].orient = 0;
                                     }
                                 }
-                                
-                            }// end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
+
+                            } // end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
                         }
                     }
-                    
+
                 } // end if bore hole antenna layout = 2 (where VHVV way but different numbers)
-                
-                
-                else if ( params.bore_hole_antenna_layout == 3 || params.            
-                         bore_hole_antenna_layout == 4 ) {   // it's V-H-H-H or V-H-H
-                    
-                    for (int j=0; j<params.number_of_strings_station; j++) {
-                        for (int k=0; k<params.number_of_antennas_string; k++) {
+                else if (params.bore_hole_antenna_layout == 3 || params.bore_hole_antenna_layout == 4) { // it's V-H-H-H or V-H-H
 
-                            if (settings1->BH_ANT_SEP_DIST_ON==0) 
-                            stations[i].strings[j].antennas[k].SetZ( -z_max + z_btw*k );
+                    for (int j = 0; j < params.number_of_strings_station; j++) {
+                        for (int k = 0; k < params.number_of_antennas_string; k++) {
 
-                            else if (settings1->BH_ANT_SEP_DIST_ON==1) {
+                            if (settings1 -> BH_ANT_SEP_DIST_ON == 0)
+                                stations[i].strings[j].antennas[k].SetZ(-z_max + z_btw * k);
+
+                            else if (settings1 -> BH_ANT_SEP_DIST_ON == 1) {
                                 z_btw_total = 0.;
-                                for (int l=0; l<k+1; l++) {
+                                for (int l = 0; l < k + 1; l++) {
                                     z_btw_total += z_btw_array[l];
                                 }
-                                stations[i].strings[j].antennas[k].SetZ( -z_max + z_btw_total );
+                                stations[i].strings[j].antennas[k].SetZ(-z_max + z_btw_total);
                             }
 
-                            
-                            if (k == 0) {   // only the first antenna is V pol
-                                stations[i].strings[j].antennas[k].type = 0;   // v-pol
+                            if (k == 0) { // only the first antenna is V pol
+                                stations[i].strings[j].antennas[k].type = 0; // v-pol
+                            } else { // other antennas are H pol
+                                stations[i].strings[j].antennas[k].type = 1; // h-pol
                             }
-                            else {  // other antennas are H pol
-                                stations[i].strings[j].antennas[k].type = 1;   // h-pol
-                            }
-                            
-                            if ( params.antenna_orientation == 0 ) {    // all borehole antennas facing same x
+
+                            if (params.antenna_orientation == 0) { // all borehole antennas facing same x
                                 stations[i].strings[j].antennas[k].orient = 0;
-                            }
-                            else if ( params.antenna_orientation == 1 ) {   // borehole antennas one next facing different way
-                                if ( j==0||j==3 ) {
-                                    if ( k==0||k==1 ) {
+                            } else if (params.antenna_orientation == 1) { // borehole antennas one next facing different way
+                                if (j == 0 || j == 3) {
+                                    if (k == 0 || k == 1) {
                                         stations[i].strings[j].antennas[k].orient = 0;
-                                    }
-                                    else {
+                                    } else {
                                         stations[i].strings[j].antennas[k].orient = 1;
                                     }
-                                }
-                                else {
-                                    if ( k==0||k==1 ) {
+                                } else {
+                                    if (k == 0 || k == 1) {
                                         stations[i].strings[j].antennas[k].orient = 1;
-                                    }
-                                    else {
+                                    } else {
                                         stations[i].strings[j].antennas[k].orient = 0;
                                     }
                                 }
-                                
-                            }// end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
+
+                            } // end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
                         }
                     }
-                    
+
                 } // end if bore hole antenna layout = 3 (where VHHH way)
+                else if (params.bore_hole_antenna_layout == 5 ||
+                    params.bore_hole_antenna_layout == 6 ||
+                    params.bore_hole_antenna_layout == 7) { // it's V-V-V-V or V-V or V
 
-                else if ( params.bore_hole_antenna_layout == 5 || 
-			  params.bore_hole_antenna_layout == 6 || 
-			  params.bore_hole_antenna_layout == 7 ) {   // it's V-V-V-V or V-V or V
-                    
-                    for (int j=0; j<params.number_of_strings_station; j++) {
-                        for (int k=0; k<params.number_of_antennas_string; k++) {
-			  
-			  if (settings1->BH_ANT_SEP_DIST_ON==0) 
-                            stations[i].strings[j].antennas[k].SetZ( -z_max + z_btw*k );
-			  
-			  else if (settings1->BH_ANT_SEP_DIST_ON==1) {
-			    z_btw_total = 0.;
-			    for (int l=0; l<k+1; l++) {
-			      z_btw_total += z_btw_array[l];
-			    }
-			    stations[i].strings[j].antennas[k].SetZ( -z_max + z_btw_total );
-			  }
+                    for (int j = 0; j < params.number_of_strings_station; j++) {
+                        for (int k = 0; k < params.number_of_antennas_string; k++) {
 
-			  stations[i].strings[j].antennas[k].type = 0;   // all antennas v-pol			  
-                            
-			  if ( params.antenna_orientation == 0 ) {    // all borehole antennas facing same x
-			    stations[i].strings[j].antennas[k].orient = 0;
-			  }
-			  else if ( params.antenna_orientation == 1 ) {   // borehole antennas one next facing different way
-			    if ( j==0||j==3 ) {
-			      if ( k==0||k==1 ) {
-				stations[i].strings[j].antennas[k].orient = 0;
-			      }
-                                    else {
-                                        stations[i].strings[j].antennas[k].orient = 1;
-                                    }
+                            if (settings1 -> BH_ANT_SEP_DIST_ON == 0)
+                                stations[i].strings[j].antennas[k].SetZ(-z_max + z_btw * k);
+
+                            else if (settings1 -> BH_ANT_SEP_DIST_ON == 1) {
+                                z_btw_total = 0.;
+                                for (int l = 0; l < k + 1; l++) {
+                                    z_btw_total += z_btw_array[l];
                                 }
-                                else {
-                                    if ( k==0||k==1 ) {
+                                stations[i].strings[j].antennas[k].SetZ(-z_max + z_btw_total);
+                            }
+
+                            stations[i].strings[j].antennas[k].type = 0; // all antennas v-pol			  
+
+                            if (params.antenna_orientation == 0) { // all borehole antennas facing same x
+                                stations[i].strings[j].antennas[k].orient = 0;
+                            } else if (params.antenna_orientation == 1) { // borehole antennas one next facing different way
+                                if (j == 0 || j == 3) {
+                                    if (k == 0 || k == 1) {
+                                        stations[i].strings[j].antennas[k].orient = 0;
+                                    } else {
                                         stations[i].strings[j].antennas[k].orient = 1;
                                     }
-                                    else {
+                                } else {
+                                    if (k == 0 || k == 1) {
+                                        stations[i].strings[j].antennas[k].orient = 1;
+                                    } else {
                                         stations[i].strings[j].antennas[k].orient = 0;
                                     }
                                 }
-                                
-                            }// end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
+
+                            } // end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
                         }
                     }
-                    
+
                 } // end if bore hole antenna layout = 5,6,7 (VVVV, VV, V)
-                
+
                 //
                 // set surface antenna postions
-                stations[i].surfaces[0].SetX( stations[i].GetX() + (R_surface * cos(PI/3.)) );
-                stations[i].surfaces[0].SetY( stations[i].GetY() + (R_surface * sin(PI/3.)) );
-                
-                stations[i].surfaces[1].SetX( stations[i].GetX() + (R_surface * cos(-PI/3.)) );
-                stations[i].surfaces[1].SetY( stations[i].GetY() + (R_surface * sin(-PI/3.)) );
-                
-                stations[i].surfaces[2].SetX( stations[i].GetX() + (R_surface * cos(PI)) );
-                stations[i].surfaces[2].SetY( stations[i].GetY() );
-                
-                stations[i].surfaces[3].SetX( stations[i].GetX() );
-                stations[i].surfaces[3].SetY( stations[i].GetY() );
-                
+                stations[i].surfaces[0].SetX(stations[i].GetX() + (R_surface * cos(PI / 3.)));
+                stations[i].surfaces[0].SetY(stations[i].GetY() + (R_surface * sin(PI / 3.)));
+
+                stations[i].surfaces[1].SetX(stations[i].GetX() + (R_surface * cos(-PI / 3.)));
+                stations[i].surfaces[1].SetY(stations[i].GetY() + (R_surface * sin(-PI / 3.)));
+
+                stations[i].surfaces[2].SetX(stations[i].GetX() + (R_surface * cos(PI)));
+                stations[i].surfaces[2].SetY(stations[i].GetY());
+
+                stations[i].surfaces[3].SetX(stations[i].GetX());
+                stations[i].surfaces[3].SetY(stations[i].GetY());
 
                 stations[i].number_of_antennas = params.number_of_strings_station * params.number_of_antennas_string;
 
-
-            }// loop over stations i
-
+            } // loop over stations i
 
             // for idealized geometry, number of antennas in a station is constant
             max_number_of_antennas_station = params.number_of_strings_station * params.number_of_antennas_string;
 
-
-
-
         } // if idealized geometry
-#ifdef ARA_UTIL_EXISTS
+        #ifdef ARA_UTIL_EXISTS
 
         else { // non-idealized geometry
 
             //for (int i=0; i<params.number_of_stations; i++) {
-      
-                //AraGeomTool *araGeom=AraGeomTool::Instance();
-                AraGeomTool *araGeom = new AraGeomTool();
-                cout<<"read AraGeomTool"<<endl;
-                
-                for (int i=0; i<params.number_of_stations; i++) {
-                    for (int j = 0; j < params.number_of_strings_station; j++){
-                        
-                        double avgX, avgY;
-                        
-                        for (int k = 0; k < params.number_of_antennas_string; k++){
-                            
-                            //int chan = GetChannelfromStringAntenna (i+1,j,k);
-                            int chan = GetChannelfromStringAntenna (i+1,j,k,settings1);
-                            
-                            stations[i].strings[j].antennas[k].SetX(stations[i].GetX()+araGeom->getStationInfo(i+1)->fAntInfo[chan-1].antLocation[0]);
-                            stations[i].strings[j].antennas[k].SetY(stations[i].GetY()+araGeom->getStationInfo(i+1)->fAntInfo[chan-1].antLocation[1]);
-                            //stations[i].strings[j].antennas[k].SetZ(araGeom->fStationInfo[i+1].fAntInfo[chan-1].antLocation[2]-double(settings1->DEPTH_CHANGE));
-                            stations[i].strings[j].antennas[k].SetZ(araGeom->getStationInfo(i+1)->fAntInfo[chan-1].antLocation[2]);
-                                                    cout <<
-                             "DetectorStation:string:antenna:X:Y:Z:: " <<
-                             i<< " : " <<
-                             j<< " : " <<
-                             k<< " : " <<
-                             stations[i].strings[j].antennas[k].GetX() << " : " <<
-                             stations[i].strings[j].antennas[k].GetY() << " : " <<
-                             stations[i].strings[j].antennas[k].GetZ() << " : " <<
-			     chan << " : " <<	
-			     //araGeom->fStationInfo[i+1].fAntInfo[chan-1].antLocation[2]-double(settings1->DEPTH_CHANGE) << " : " <<
-			     //double(settings1->DEPTH_CHANGE) << " : " <<
-                             endl;
-                             
-                        }
-                        
-                        //int chanstring = GetChannelfromStringAntenna (i+1, j,2);
-                        int chanstring = GetChannelfromStringAntenna (i+1, j,2,settings1);
-                        
-                        stations[i].strings[j].SetX(stations[i].GetX()+araGeom->getStationInfo(i+1)->fAntInfo[chanstring-1].antLocation[0]);
-                        stations[i].strings[j].SetY(stations[i].GetY()+araGeom->getStationInfo(i+1)->fAntInfo[chanstring-1].antLocation[1]);
-                        
+
+            //AraGeomTool *araGeom=AraGeomTool::Instance();
+            AraGeomTool * araGeom = new AraGeomTool();
+            cout << "read AraGeomTool" << endl;
+
+            for (int i = 0; i < params.number_of_stations; i++) {
+                for (int j = 0; j < params.number_of_strings_station; j++) {
+
+                    double avgX, avgY;
+
+                    for (int k = 0; k < params.number_of_antennas_string; k++) {
+
+                        //int chan = GetChannelfromStringAntenna (i+1,j,k);
+                        int chan = GetChannelfromStringAntenna(i + 1, j, k, settings1);
+
+                        stations[i].strings[j].antennas[k].SetX(stations[i].GetX() + araGeom -> getStationInfo(i + 1) -> fAntInfo[chan - 1].antLocation[0]);
+                        stations[i].strings[j].antennas[k].SetY(stations[i].GetY() + araGeom -> getStationInfo(i + 1) -> fAntInfo[chan - 1].antLocation[1]);
+                        //stations[i].strings[j].antennas[k].SetZ(araGeom->fStationInfo[i+1].fAntInfo[chan-1].antLocation[2]-double(settings1->DEPTH_CHANGE));
+                        stations[i].strings[j].antennas[k].SetZ(araGeom -> getStationInfo(i + 1) -> fAntInfo[chan - 1].antLocation[2]);
+                        cout <<
+                            "DetectorStation:string:antenna:X:Y:Z:: " <<
+                            i << " : " <<
+                            j << " : " <<
+                            k << " : " <<
+                            stations[i].strings[j].antennas[k].GetX() << " : " <<
+                            stations[i].strings[j].antennas[k].GetY() << " : " <<
+                            stations[i].strings[j].antennas[k].GetZ() << " : " <<
+                            chan << " : " <<
+                            //araGeom->fStationInfo[i+1].fAntInfo[chan-1].antLocation[2]-double(settings1->DEPTH_CHANGE) << " : " <<
+                            //double(settings1->DEPTH_CHANGE) << " : " <<
+                            endl;
+
                     }
-                
-                
+
+                    //int chanstring = GetChannelfromStringAntenna (i+1, j,2);
+                    int chanstring = GetChannelfromStringAntenna(i + 1, j, 2, settings1);
+
+                    stations[i].strings[j].SetX(stations[i].GetX() + araGeom -> getStationInfo(i + 1) -> fAntInfo[chanstring - 1].antLocation[0]);
+                    stations[i].strings[j].SetY(stations[i].GetY() + araGeom -> getStationInfo(i + 1) -> fAntInfo[chanstring - 1].antLocation[1]);
+
+                }
+
                 //
                 // set antenna postions in borehole
                 // and set type (h or v pol antenna) and set orientation (facing x or y)
-                if ( params.bore_hole_antenna_layout == 0 || params.bore_hole_antenna_layout == 1) {
-                    
-                    for (int j=0; j<params.number_of_strings_station; j++) {
-                        for (int k=0; k<params.number_of_antennas_string; k++) {
+                if (params.bore_hole_antenna_layout == 0 || params.bore_hole_antenna_layout == 1) {
 
-                            if (k%2 == 0) {
-                                stations[i].strings[j].antennas[k].type = 0;   // v-pol
+                    for (int j = 0; j < params.number_of_strings_station; j++) {
+                        for (int k = 0; k < params.number_of_antennas_string; k++) {
+
+                            if (k % 2 == 0) {
+                                stations[i].strings[j].antennas[k].type = 0; // v-pol
+                            } else {
+                                stations[i].strings[j].antennas[k].type = 1; // h-pol
                             }
-                            else {
-                                stations[i].strings[j].antennas[k].type = 1;   // h-pol
-                            }
-                            
-                            if ( params.antenna_orientation == 0 ) {    // all borehole antennas facing same x
+
+                            if (params.antenna_orientation == 0) { // all borehole antennas facing same x
                                 stations[i].strings[j].antennas[k].orient = 0;
-                            }
-                            else if ( params.antenna_orientation == 1 ) {   // borehole antennas one next facing different way
-                                if ( j==0||j==3 ) {
-                                    if ( k==0||k==1 ) {
+                            } else if (params.antenna_orientation == 1) { // borehole antennas one next facing different way
+                                if (j == 0 || j == 3) {
+                                    if (k == 0 || k == 1) {
                                         stations[i].strings[j].antennas[k].orient = 0;
-                                    }
-                                    else {
+                                    } else {
                                         stations[i].strings[j].antennas[k].orient = 1;
                                     }
-                                }
-                                else {
-                                    if ( k==0||k==1 ) {
+                                } else {
+                                    if (k == 0 || k == 1) {
                                         stations[i].strings[j].antennas[k].orient = 1;
-                                    }
-                                    else {
+                                    } else {
                                         stations[i].strings[j].antennas[k].orient = 0;
                                     }
                                 }
-                                
-                            }// end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
+
+                            } // end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
                         }
                     }
-                    
+
                 } // end if bore hole antenna layout = 0 or 1 (where VHVH way but different numbers)
-                
-                
-                else if ( params.bore_hole_antenna_layout == 2) {   // it's V-H-V-V
-                    
-                    for (int j=0; j<params.number_of_strings_station; j++) {
-                        for (int k=0; k<params.number_of_antennas_string; k++) {
-                            
-                            if (k == 1) {   // only the second antenna is H pol
-                                stations[i].strings[j].antennas[k].type = 1;   // h-pol
+                else if (params.bore_hole_antenna_layout == 2) { // it's V-H-V-V
+
+                    for (int j = 0; j < params.number_of_strings_station; j++) {
+                        for (int k = 0; k < params.number_of_antennas_string; k++) {
+
+                            if (k == 1) { // only the second antenna is H pol
+                                stations[i].strings[j].antennas[k].type = 1; // h-pol
+                            } else { // other antennas are V pol
+                                stations[i].strings[j].antennas[k].type = 0; // v-pol
                             }
-                            else {  // other antennas are V pol
-                                stations[i].strings[j].antennas[k].type = 0;   // v-pol
-                            }
-                            
-                            if ( params.antenna_orientation == 0 ) {    // all borehole antennas facing same x
+
+                            if (params.antenna_orientation == 0) { // all borehole antennas facing same x
                                 stations[i].strings[j].antennas[k].orient = 0;
-                            }
-                            else if ( params.antenna_orientation == 1 ) {   // borehole antennas one next facing different way
-                                if ( j==0||j==3 ) {
-                                    if ( k==0||k==1 ) {
+                            } else if (params.antenna_orientation == 1) { // borehole antennas one next facing different way
+                                if (j == 0 || j == 3) {
+                                    if (k == 0 || k == 1) {
                                         stations[i].strings[j].antennas[k].orient = 0;
-                                    }
-                                    else {
+                                    } else {
                                         stations[i].strings[j].antennas[k].orient = 1;
                                     }
-                                }
-                                else {
-                                    if ( k==0||k==1 ) {
+                                } else {
+                                    if (k == 0 || k == 1) {
                                         stations[i].strings[j].antennas[k].orient = 1;
-                                    }
-                                    else {
+                                    } else {
                                         stations[i].strings[j].antennas[k].orient = 0;
                                     }
                                 }
-                                
-                            }// end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
+
+                            } // end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
                         }
                     }
-                    
+
                 } // end if bore hole antenna layout = 2 (where VHVV way but different numbers)
-                
-                
-                else if ( params.bore_hole_antenna_layout == 3 || params.            
-                         bore_hole_antenna_layout == 4 ) {   // it's V-H-H-H or V-H-H
-                    
-                    for (int j=0; j<params.number_of_strings_station; j++) {
-                        for (int k=0; k<params.number_of_antennas_string; k++) {
-                            
-                            if (k == 0) {   // only the first antenna is V pol
-                                stations[i].strings[j].antennas[k].type = 0;   // v-pol
+                else if (params.bore_hole_antenna_layout == 3 || params.bore_hole_antenna_layout == 4) { // it's V-H-H-H or V-H-H
+
+                    for (int j = 0; j < params.number_of_strings_station; j++) {
+                        for (int k = 0; k < params.number_of_antennas_string; k++) {
+
+                            if (k == 0) { // only the first antenna is V pol
+                                stations[i].strings[j].antennas[k].type = 0; // v-pol
+                            } else { // other antennas are H pol
+                                stations[i].strings[j].antennas[k].type = 1; // h-pol
                             }
-                            else {  // other antennas are H pol
-                                stations[i].strings[j].antennas[k].type = 1;   // h-pol
-                            }
-                            
-                            if ( params.antenna_orientation == 0 ) {    // all borehole antennas facing same x
+
+                            if (params.antenna_orientation == 0) { // all borehole antennas facing same x
                                 stations[i].strings[j].antennas[k].orient = 0;
-                            }
-                            else if ( params.antenna_orientation == 1 ) {   // borehole antennas one next facing different way
-                                if ( j==0||j==3 ) {
-                                    if ( k==0||k==1 ) {
+                            } else if (params.antenna_orientation == 1) { // borehole antennas one next facing different way
+                                if (j == 0 || j == 3) {
+                                    if (k == 0 || k == 1) {
                                         stations[i].strings[j].antennas[k].orient = 0;
-                                    }
-                                    else {
+                                    } else {
                                         stations[i].strings[j].antennas[k].orient = 1;
                                     }
-                                }
-                                else {
-                                    if ( k==0||k==1 ) {
+                                } else {
+                                    if (k == 0 || k == 1) {
                                         stations[i].strings[j].antennas[k].orient = 1;
-                                    }
-                                    else {
+                                    } else {
                                         stations[i].strings[j].antennas[k].orient = 0;
                                     }
                                 }
-                                
-                            }// end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
+
+                            } // end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
                         }
                     }
-                    
+
                 } // end if bore hole antenna layout = 3 (where VHHH way)
-                
-                
-                
-                
+
                 //
                 // set surface antenna postions
-                stations[i].surfaces[0].SetX( stations[i].GetX() + (R_surface * cos(PI/3.)) );
-                stations[i].surfaces[0].SetY( stations[i].GetY() + (R_surface * sin(PI/3.)) );
-                
-                stations[i].surfaces[1].SetX( stations[i].GetX() + (R_surface * cos(-PI/3.)) );
-                stations[i].surfaces[1].SetY( stations[i].GetY() + (R_surface * sin(-PI/3.)) );
-                
-                stations[i].surfaces[2].SetX( stations[i].GetX() + (R_surface * cos(PI)) );
-                stations[i].surfaces[2].SetY( stations[i].GetY() );
-                
-                stations[i].surfaces[3].SetX( stations[i].GetX() );
-                stations[i].surfaces[3].SetY( stations[i].GetY() );
+                stations[i].surfaces[0].SetX(stations[i].GetX() + (R_surface * cos(PI / 3.)));
+                stations[i].surfaces[0].SetY(stations[i].GetY() + (R_surface * sin(PI / 3.)));
 
-                
+                stations[i].surfaces[1].SetX(stations[i].GetX() + (R_surface * cos(-PI / 3.)));
+                stations[i].surfaces[1].SetY(stations[i].GetY() + (R_surface * sin(-PI / 3.)));
+
+                stations[i].surfaces[2].SetX(stations[i].GetX() + (R_surface * cos(PI)));
+                stations[i].surfaces[2].SetY(stations[i].GetY());
+
+                stations[i].surfaces[3].SetX(stations[i].GetX());
+                stations[i].surfaces[3].SetY(stations[i].GetY());
+
             } // end loop over stations i
 
-
             //}// end loop over stations i
-            
 
             int antenna_count = 0;
             max_number_of_antennas_station = 0;
             // for non-idealized geometry, it's better to actually count number of stations
-            for (int i=0; i<(int)(stations.size()); i++) {
-            
+            for (int i = 0; i < (int)(stations.size()); i++) {
+
                 antenna_count = 0;
-                for (int j=0; j<(int)(stations[i].strings.size()); j++) {
-                    for (int k=0; k<(int)(stations[i].strings[j].antennas.size()); k++) {
+                for (int j = 0; j < (int)(stations[i].strings.size()); j++) {
+                    for (int k = 0; k < (int)(stations[i].strings[j].antennas.size()); k++) {
                         antenna_count++;
                     }
                 }
@@ -990,18 +828,14 @@ Detector::Detector(Settings *settings1, IceModel *icesurface, string setupfile) 
                 if (max_number_of_antennas_station < antenna_count) max_number_of_antennas_station = antenna_count;
             }
 
-            
-        }// if non-idealized geom
-#endif
-        
-        
+        } // if non-idealized geom
+        #endif
 
-	ReadAllAntennaGains(settings1);
-	
-	//	if (settings1->NOISE == 2){
-	  ReadNoiseFigure("./data/ARA02_noiseFig.txt", settings1);
-	  //	}
+        ReadAllAntennaGains(settings1);
 
+        //	if (settings1->NOISE == 2){
+        ReadNoiseFigure("./data/ARA02_noiseFig.txt", settings1);
+        //	}
 
         // read filter file!!
         ReadFilter("./data/filter.csv", settings1);
@@ -1010,465 +844,381 @@ Detector::Detector(Settings *settings1, IceModel *icesurface, string setupfile) 
         // read FOAM gain file!!
         ReadFOAM("./data/FOAM.csv", settings1);
         // read gain offset for chs file!!
-        ReadGainOffset_TestBed("./data/preamp_ch_gain_offset.csv", settings1);// only TestBed for now
+        ReadGainOffset_TestBed("./data/preamp_ch_gain_offset.csv", settings1); // only TestBed for now
         // read threshold offset for chs file!!
-        ReadThresOffset_TestBed("./data/threshold_offset.csv", settings1);// only TestBed for now
-	// read threshold values for chs file
-	ReadThres_TestBed("./data/thresholds_TB.csv", settings1);// only TestBed for now
+        ReadThresOffset_TestBed("./data/threshold_offset.csv", settings1); // only TestBed for now
+        // read threshold values for chs file
+        ReadThres_TestBed("./data/thresholds_TB.csv", settings1); // only TestBed for now
         // read system temperature for chs file!!
-	cout << "check read testbed temp1" << endl;
-        if (settings1->NOISE_CHANNEL_MODE != 0) {
-	  
-            ReadTemp_TestBed("./data/system_temperature.csv", settings1);// only TestBed for now
+        cout << "check read testbed temp1" << endl;
+        if (settings1 -> NOISE_CHANNEL_MODE != 0) {
+
+            ReadTemp_TestBed("./data/system_temperature.csv", settings1); // only TestBed for now
 
         }
         // read total elec. chain response file!!
-        cout<<"start read elect chain"<<endl;
-        if(settings1->CUSTOM_ELECTRONICS==0){
+        cout << "start read elect chain" << endl;
+        if (settings1 -> CUSTOM_ELECTRONICS == 0) {
             //read the standard ARA electronics
-            cout<<"     Reading standard ARA electronics response"<<endl;
-             ReadElectChain("./data/ARA_Electronics_TotalGain_TwoFilters.txt", settings1);
+            cout << "     Reading standard ARA electronics response" << endl;
+            ReadElectChain("./data/ARA_Electronics_TotalGain_TwoFilters.txt", settings1);
             //ReadElectChain("./data/ARA_Electronics_TotalGainPhase.txt", settings1);
-        }
-        else if (settings1->CUSTOM_ELECTRONICS==1){
+        } else if (settings1 -> CUSTOM_ELECTRONICS == 1) {
             //read a custom user defined electronics gain
-            cout<<"     Reading custom electronics response"<<endl;
-             ReadElectChain("./data/custom_electronics.txt", settings1);
+            cout << "     Reading custom electronics response" << endl;
+            ReadElectChain("./data/custom_electronics.txt", settings1);
         }
-        cout<<"done read elect chain"<<endl;
-        
-        
+        cout << "done read elect chain" << endl;
+
     } // if mode == 1
-    
-    
-    
-    
+
     /////////////////////////////////////////////////////////////////////////////////    
-    
-    
-    
     else if (mode == 2) {
-        cout<<"\n\tDector mode 2 : Pentagon"<<endl;
-        cout<<"\n\tBy default, ARA-37 is set"<<endl;
-        ifstream ARA37( ARA37_file.c_str() );
-        cout<<"We use "<<ARA37_file.c_str()<<" as antenna info."<<endl;
+        cout << "\n\tDector mode 2 : Pentagon" << endl;
+        cout << "\n\tBy default, ARA-37 is set" << endl;
+        ifstream ARA37(ARA37_file.c_str());
+        cout << "We use " << ARA37_file.c_str() << " as antenna info." << endl;
 
-
-        
         //
         // initialize info
         params.number_of_stations = 37;
-        params.number_of_strings_station = 4;   // ARA-1 has 4 strings
+        params.number_of_strings_station = 4; // ARA-1 has 4 strings
         params.number_of_antennas_string = 4; // 4 antennas on each strings
         params.number_of_surfaces_station = 4;
-        
+
         //double core_x = 0.;  // all units are in meter
         //double core_y = 0.;
-        params.core_x = 10000.;  // all units are in meter
+        params.core_x = 10000.; // all units are in meter
         params.core_y = 10000.;
         double R_string = 10.;
         double R_surface = 60.;
         double z_max = 200.;
         double z_btw = 10.;
         double z_btw_array[6]; // assume there will be less than 6 bore hole antennas at each string
-	// these z_btw array will be used when settings->BH_ANT_SEP_DIST_ON=1 case
-        for (int i=0; i<6; i++) {
-            if (i==0) z_btw_array[i] = 0.;
+        // these z_btw array will be used when settings->BH_ANT_SEP_DIST_ON=1 case
+        for (int i = 0; i < 6; i++) {
+            if (i == 0) z_btw_array[i] = 0.;
             //else z_btw_array[i] = z_btw;
-            else if (i==1) z_btw_array[i] = 2.;
-            else if (i==2) z_btw_array[i] = 15.;
-            else if (i==3) z_btw_array[i] = 2.;
+            else if (i == 1) z_btw_array[i] = 2.;
+            else if (i == 2) z_btw_array[i] = 15.;
+            else if (i == 3) z_btw_array[i] = 2.;
             else z_btw_array[i] = z_btw;
         }
         double z_btw_total;
-        params.stations_per_side = 4;       // total 37 stations
-        params.station_spacing = 2000.;     // 2km spacing
-        params.antenna_orientation = 0;     // all antenna facing x
-        params.bore_hole_antenna_layout = settings1->BORE_HOLE_ANTENNA_LAYOUT;
+        params.stations_per_side = 4; // total 37 stations
+        params.station_spacing = 2000.; // 2km spacing
+        params.antenna_orientation = 0; // all antenna facing x
+        params.bore_hole_antenna_layout = settings1 -> BORE_HOLE_ANTENNA_LAYOUT;
         // finish initialization
         //
-        
-        
-        
-        
-        
-        
+
         // Read new parameters if there are...
-        if ( ARA37.is_open() ) {
-            while (ARA37.good() ) {
-                getline (ARA37, line);
-                
-                if (line[0] != "/"[0]) {
-                    label = line.substr(0, line.find_first_of("=") );
-                    
+        if (ARA37.is_open()) {
+            while (ARA37.good()) {
+                getline(ARA37, line);
+
+                if (line[0] != "/" [0]) {
+                    label = line.substr(0, line.find_first_of("="));
+
                     if (label == "core_x") {
-                        params.core_x = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read core_x"<<endl;
-                    }
-                    else if (label == "core_y") {
-                        params.core_y = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read core_y"<<endl;
-                    }
-                    else if (label == "R_string") {
-                        R_string = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read R_string"<<endl;
-                    }
-                    else if (label == "R_surface") {
-                        R_surface = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read R_surface"<<endl;
-                    }
-                    else if (label == "z_max") {
-                        z_max = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_max"<<endl;
-                    }
-                    else if (label == "z_btw") {
-                        z_btw = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_btw"<<endl;
-                    }
-                    else if (label == "z_btw01") {
-                        z_btw_array[1] = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_btw bh ant0 and ant1"<<endl;
-                    }
-                    else if (label == "z_btw12") {
-                        z_btw_array[2] = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_btw bh ant1 and ant2"<<endl;
-                    }
-                    else if (label == "z_btw23") {
-                        z_btw_array[3] = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_btw bh ant2 and ant3"<<endl;
-                    }
-                    else if (label == "z_btw34") {
-                        z_btw_array[4] = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_btw bh ant3 and ant4"<<endl;
-                    }
-                    else if (label == "z_btw45") {
-                        z_btw_array[5] = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_btw bh ant4 and ant5"<<endl;
-                    }
-                    else if (label == "stations_per_side") {
-                        params.stations_per_side = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read stations_per_side"<<endl;
-                    }
-                    else if (label == "station_spacing") {
-                        params.station_spacing = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read station_spacting"<<endl;
-                    }
-                    else if (label == "antenna_orientation") {
-                        params.antenna_orientation = atoi( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read antenna_orientation"<<endl;
+                        params.core_x = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read core_x" << endl;
+                    } else if (label == "core_y") {
+                        params.core_y = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read core_y" << endl;
+                    } else if (label == "R_string") {
+                        R_string = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read R_string" << endl;
+                    } else if (label == "R_surface") {
+                        R_surface = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read R_surface" << endl;
+                    } else if (label == "z_max") {
+                        z_max = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_max" << endl;
+                    } else if (label == "z_btw") {
+                        z_btw = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_btw" << endl;
+                    } else if (label == "z_btw01") {
+                        z_btw_array[1] = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_btw bh ant0 and ant1" << endl;
+                    } else if (label == "z_btw12") {
+                        z_btw_array[2] = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_btw bh ant1 and ant2" << endl;
+                    } else if (label == "z_btw23") {
+                        z_btw_array[3] = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_btw bh ant2 and ant3" << endl;
+                    } else if (label == "z_btw34") {
+                        z_btw_array[4] = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_btw bh ant3 and ant4" << endl;
+                    } else if (label == "z_btw45") {
+                        z_btw_array[5] = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_btw bh ant4 and ant5" << endl;
+                    } else if (label == "stations_per_side") {
+                        params.stations_per_side = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read stations_per_side" << endl;
+                    } else if (label == "station_spacing") {
+                        params.station_spacing = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read station_spacting" << endl;
+                    } else if (label == "antenna_orientation") {
+                        params.antenna_orientation = atoi(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read antenna_orientation" << endl;
                     }
                 }
             }
             ARA37.close();
         }
         // finished reading new parameters
-        
-        
-        
+
         // set number of antennas in a string
         if (params.bore_hole_antenna_layout == 0) { // VHVH layout
             params.number_of_antennas_string = 4;
-        }
-        else if (params.bore_hole_antenna_layout == 1) { // VHV layout
+        } else if (params.bore_hole_antenna_layout == 1) { // VHV layout
+            params.number_of_antennas_string = 3;
+        } else if (params.bore_hole_antenna_layout == 2) { // VHVV layout
+            params.number_of_antennas_string = 4;
+        } else if (params.bore_hole_antenna_layout == 3) { // VHHH layout
+            params.number_of_antennas_string = 4;
+        } else if (params.bore_hole_antenna_layout == 4) { // VHH layout
             params.number_of_antennas_string = 3;
         }
-        else if (params.bore_hole_antenna_layout == 2) { // VHVV layout
-            params.number_of_antennas_string = 4;
-        }
-        else if (params.bore_hole_antenna_layout == 3) { // VHHH layout
-            params.number_of_antennas_string = 4;
-        }
-        else if (params.bore_hole_antenna_layout == 4) { // VHH layout
-            params.number_of_antennas_string = 3;
-        }
-        
-        
-        
-        
-        
+
         //
         // caculate number of stations, strings, antennas 
         params.number_of_stations = 1 + (3 * params.stations_per_side) * (params.stations_per_side - 1);
-        
+
         params.number_of_strings = params.number_of_stations * params.number_of_strings_station;
         params.number_of_antennas = params.number_of_strings * params.number_of_antennas_string;
         // 
-        
-        
-        
+
         //
         // prepare vectors
-        for (int i=0; i<params.number_of_stations; i++) {
+        for (int i = 0; i < params.number_of_stations; i++) {
             stations.push_back(temp_station);
-            
-            for (int j=0; j<params.number_of_surfaces_station; j++) {
+
+            for (int j = 0; j < params.number_of_surfaces_station; j++) {
                 stations[i].surfaces.push_back(temp_surface);
             }
-            
-            for (int k=0; k<params.number_of_strings_station; k++) {
+
+            for (int k = 0; k < params.number_of_strings_station; k++) {
                 stations[i].strings.push_back(temp_string);
-                
-                for (int l=0; l<params.number_of_antennas_string; l++) {
+
+                for (int l = 0; l < params.number_of_antennas_string; l++) {
                     stations[i].strings[k].antennas.push_back(temp_antenna);
                 }
-                
+
             }
-            
-            
+
         }
         // end perpare vectors
         //
-        
-        
-        
-        
-        
-        
-        
-        
+
         //
         // for ARA-37 (or more than 1 station case), need code for setting position for all 37 stations here!
         //
         //
         // here, this only works for pentagon shape!
         //
-        double y_offset = (double)params.station_spacing * sqrt(3) / 2.;
-        
+        double y_offset = (double) params.station_spacing * sqrt(3) / 2.;
+
         int station_count = 0;
-        
-        for (int irow = 0; irow < ((int)params.stations_per_side * 2)-1; irow++) {
-            double current_y = y_offset * ( (double)params.stations_per_side - 1 - irow) + params.core_y;
-            int stations_this_row = (2 * (int)params.stations_per_side - 1) - abs((int)params.stations_per_side - 1 - irow);
-            
+
+        for (int irow = 0; irow < ((int) params.stations_per_side * 2) - 1; irow++) {
+            double current_y = y_offset * ((double) params.stations_per_side - 1 - irow) + params.core_y;
+            int stations_this_row = (2 * (int) params.stations_per_side - 1) - abs((int) params.stations_per_side - 1 - irow);
+
             for (int istation = 0; istation < stations_this_row; istation++) {
-                if (station_count < (int)params.number_of_stations) {
-                    stations[station_count].SetY( current_y );
-                    stations[station_count].SetX( (double)params.station_spacing * ((double)istation - ((double)stations_this_row - 1.) / 2.) + params.core_x );
+                if (station_count < (int) params.number_of_stations) {
+                    stations[station_count].SetY(current_y);
+                    stations[station_count].SetX((double) params.station_spacing * ((double) istation - ((double) stations_this_row - 1.) / 2.) + params.core_x);
                     station_count++;
-                }
-                else {
-                    cout<<"\n\tError, too many stations !"<<endl;
+                } else {
+                    cout << "\n\tError, too many stations !" << endl;
                 }
             }
         }
         // finished setting all stations' position
-        
-        
-        cout<<"total station_count : "<<station_count<<endl;
-        if (station_count != (int)params.number_of_stations) cout<<"\n\tError, station number not match !"<<endl;        
-        
+
+        cout << "total station_count : " << station_count << endl;
+        if (station_count != (int) params.number_of_stations) cout << "\n\tError, station number not match !" << endl;
+
         //
         // set antenna values from parameters
         // set station positions
-        for (int i=0; i<params.number_of_stations; i++) {
-            
+        for (int i = 0; i < params.number_of_stations; i++) {
+
             //
             // set string postions based on station position
             //            for (int j=0; j<params.number_of_strings_station; j++) {
             //            stations[i].string[0].x = stations[i].x - (R_string / 1.414);
-            stations[i].strings[0].SetX( stations[i].GetX() - (R_string * cos(PI/4.)) );
-            stations[i].strings[0].SetY( stations[i].GetY() + (R_string * sin(PI/4.)) );
-            
-            stations[i].strings[1].SetX( stations[i].GetX() + (R_string * cos(PI/4.)) );
-            stations[i].strings[1].SetY( stations[i].GetY() + (R_string * sin(PI/4.)) );
-            
-            stations[i].strings[2].SetX( stations[i].GetX() - (R_string * cos(PI/4.)) );
-            stations[i].strings[2].SetY( stations[i].GetY() - (R_string * sin(PI/4.)) );
-            
-            stations[i].strings[3].SetX( stations[i].GetX() + (R_string * cos(PI/4.)) );
-            stations[i].strings[3].SetY( stations[i].GetY() - (R_string * sin(PI/4.)) );
-            
-            
-            
-            
+            stations[i].strings[0].SetX(stations[i].GetX() - (R_string * cos(PI / 4.)));
+            stations[i].strings[0].SetY(stations[i].GetY() + (R_string * sin(PI / 4.)));
+
+            stations[i].strings[1].SetX(stations[i].GetX() + (R_string * cos(PI / 4.)));
+            stations[i].strings[1].SetY(stations[i].GetY() + (R_string * sin(PI / 4.)));
+
+            stations[i].strings[2].SetX(stations[i].GetX() - (R_string * cos(PI / 4.)));
+            stations[i].strings[2].SetY(stations[i].GetY() - (R_string * sin(PI / 4.)));
+
+            stations[i].strings[3].SetX(stations[i].GetX() + (R_string * cos(PI / 4.)));
+            stations[i].strings[3].SetY(stations[i].GetY() - (R_string * sin(PI / 4.)));
+
             //
             // set antenna postions in borehole
             // and set type (h or v pol antenna) and set orientation (facing x or y)
-            if ( params.bore_hole_antenna_layout == 0 || params.bore_hole_antenna_layout == 1) {
-                for (int j=0; j<params.number_of_strings_station; j++) {
-                    for (int k=0; k<params.number_of_antennas_string; k++) {
+            if (params.bore_hole_antenna_layout == 0 || params.bore_hole_antenna_layout == 1) {
+                for (int j = 0; j < params.number_of_strings_station; j++) {
+                    for (int k = 0; k < params.number_of_antennas_string; k++) {
 
-                        if (settings1->BH_ANT_SEP_DIST_ON==0) 
-                        stations[i].strings[j].antennas[k].SetZ( -z_max + z_btw*k );
+                        if (settings1 -> BH_ANT_SEP_DIST_ON == 0)
+                            stations[i].strings[j].antennas[k].SetZ(-z_max + z_btw * k);
 
-                        else if (settings1->BH_ANT_SEP_DIST_ON==1) {
+                        else if (settings1 -> BH_ANT_SEP_DIST_ON == 1) {
                             z_btw_total = 0.;
-                            for (int l=0; l<k+1; l++) {
+                            for (int l = 0; l < k + 1; l++) {
                                 z_btw_total += z_btw_array[l];
                             }
-                            stations[i].strings[j].antennas[k].SetZ( -z_max + z_btw_total );
+                            stations[i].strings[j].antennas[k].SetZ(-z_max + z_btw_total);
                         }
-                        
-                        if (k%2 == 0) {
-                            stations[i].strings[j].antennas[k].type = 0;   // v-pol
+
+                        if (k % 2 == 0) {
+                            stations[i].strings[j].antennas[k].type = 0; // v-pol
+                        } else {
+                            stations[i].strings[j].antennas[k].type = 1; // h-pol
                         }
-                        else {
-                            stations[i].strings[j].antennas[k].type = 1;   // h-pol
-                        }
-                        
-                        if ( params.antenna_orientation == 0 ) {    // all borehole antennas facing same x
+
+                        if (params.antenna_orientation == 0) { // all borehole antennas facing same x
                             stations[i].strings[j].antennas[k].orient = 0;
-                        }
-                        else if ( params.antenna_orientation == 1 ) {   // borehole antennas one next facing different way
-                            if ( j==0||j==3 ) {
-                                if ( k==0||k==1 ) {
+                        } else if (params.antenna_orientation == 1) { // borehole antennas one next facing different way
+                            if (j == 0 || j == 3) {
+                                if (k == 0 || k == 1) {
                                     stations[i].strings[j].antennas[k].orient = 0;
-                                }
-                                else {
+                                } else {
                                     stations[i].strings[j].antennas[k].orient = 1;
                                 }
-                            }
-                            else {
-                                if ( k==0||k==1 ) {
+                            } else {
+                                if (k == 0 || k == 1) {
                                     stations[i].strings[j].antennas[k].orient = 1;
-                                }
-                                else {
+                                } else {
                                     stations[i].strings[j].antennas[k].orient = 0;
                                 }
                             }
-                            
-                        }// end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
+
+                        } // end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
                     }
                 }
             } // end if bore hole antenna layout = 0 or 1 (where VHVH way but different numbers)
-            
-            
-            else if ( params.bore_hole_antenna_layout == 2) {   // it's V-H-V-V
-                for (int j=0; j<params.number_of_strings_station; j++) {
-                    for (int k=0; k<params.number_of_antennas_string; k++) {
+            else if (params.bore_hole_antenna_layout == 2) { // it's V-H-V-V
+                for (int j = 0; j < params.number_of_strings_station; j++) {
+                    for (int k = 0; k < params.number_of_antennas_string; k++) {
 
-                        if (settings1->BH_ANT_SEP_DIST_ON==0) 
-                        stations[i].strings[j].antennas[k].SetZ( -z_max + z_btw*k );
+                        if (settings1 -> BH_ANT_SEP_DIST_ON == 0)
+                            stations[i].strings[j].antennas[k].SetZ(-z_max + z_btw * k);
 
-                        else if (settings1->BH_ANT_SEP_DIST_ON==1) {
+                        else if (settings1 -> BH_ANT_SEP_DIST_ON == 1) {
                             z_btw_total = 0.;
-                            for (int l=0; l<k+1; l++) {
+                            for (int l = 0; l < k + 1; l++) {
                                 z_btw_total += z_btw_array[l];
                             }
-                            stations[i].strings[j].antennas[k].SetZ( -z_max + z_btw_total );
+                            stations[i].strings[j].antennas[k].SetZ(-z_max + z_btw_total);
                         }
-                        
-                        if (k == 1) {   // only the second antenna is H pol
-                            stations[i].strings[j].antennas[k].type = 1;   // h-pol
+
+                        if (k == 1) { // only the second antenna is H pol
+                            stations[i].strings[j].antennas[k].type = 1; // h-pol
+                        } else { // other antennas are V pol
+                            stations[i].strings[j].antennas[k].type = 0; // v-pol
                         }
-                        else {  // other antennas are V pol
-                            stations[i].strings[j].antennas[k].type = 0;   // v-pol
-                        }
-                        
-                        if ( params.antenna_orientation == 0 ) {    // all borehole antennas facing same x
+
+                        if (params.antenna_orientation == 0) { // all borehole antennas facing same x
                             stations[i].strings[j].antennas[k].orient = 0;
-                        }
-                        else if ( params.antenna_orientation == 1 ) {   // borehole antennas one next facing different way
-                            if ( j==0||j==3 ) {
-                                if ( k==0||k==1 ) {
+                        } else if (params.antenna_orientation == 1) { // borehole antennas one next facing different way
+                            if (j == 0 || j == 3) {
+                                if (k == 0 || k == 1) {
                                     stations[i].strings[j].antennas[k].orient = 0;
-                                }
-                                else {
+                                } else {
                                     stations[i].strings[j].antennas[k].orient = 1;
                                 }
-                            }
-                            else {
-                                if ( k==0||k==1 ) {
+                            } else {
+                                if (k == 0 || k == 1) {
                                     stations[i].strings[j].antennas[k].orient = 1;
-                                }
-                                else {
+                                } else {
                                     stations[i].strings[j].antennas[k].orient = 0;
                                 }
                             }
-                            
-                        }// end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
+
+                        } // end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
                     }
                 }
             } // end if bore hole antenna layout = 0 or 1 (where VHVH way but different numbers)
-            
-            
-            
-            else if ( params.bore_hole_antenna_layout == 3 || params.bore_hole_antenna_layout == 4 ) {   // it's V-H-H-H or V-H-H
-                for (int j=0; j<params.number_of_strings_station; j++) {
-                    for (int k=0; k<params.number_of_antennas_string; k++) {
+            else if (params.bore_hole_antenna_layout == 3 || params.bore_hole_antenna_layout == 4) { // it's V-H-H-H or V-H-H
+                for (int j = 0; j < params.number_of_strings_station; j++) {
+                    for (int k = 0; k < params.number_of_antennas_string; k++) {
 
-                        if (settings1->BH_ANT_SEP_DIST_ON==0) 
-                        stations[i].strings[j].antennas[k].SetZ( -z_max + z_btw*k );
+                        if (settings1 -> BH_ANT_SEP_DIST_ON == 0)
+                            stations[i].strings[j].antennas[k].SetZ(-z_max + z_btw * k);
 
-                        else if (settings1->BH_ANT_SEP_DIST_ON==1) {
+                        else if (settings1 -> BH_ANT_SEP_DIST_ON == 1) {
                             z_btw_total = 0.;
-                            for (int l=0; l<k+1; l++) {
+                            for (int l = 0; l < k + 1; l++) {
                                 z_btw_total += z_btw_array[l];
                             }
-                            stations[i].strings[j].antennas[k].SetZ( -z_max + z_btw_total );
+                            stations[i].strings[j].antennas[k].SetZ(-z_max + z_btw_total);
                         }
-                        
-                        if (k == 0) {   // only the first antenna is V pol
-                            stations[i].strings[j].antennas[k].type = 0;   // v-pol
+
+                        if (k == 0) { // only the first antenna is V pol
+                            stations[i].strings[j].antennas[k].type = 0; // v-pol
+                        } else { // other antennas are H pol
+                            stations[i].strings[j].antennas[k].type = 1; // h-pol
                         }
-                        else {  // other antennas are H pol
-                            stations[i].strings[j].antennas[k].type = 1;   // h-pol
-                        }
-                        
-                        if ( params.antenna_orientation == 0 ) {    // all borehole antennas facing same x
+
+                        if (params.antenna_orientation == 0) { // all borehole antennas facing same x
                             stations[i].strings[j].antennas[k].orient = 0;
-                        }
-                        else if ( params.antenna_orientation == 1 ) {   // borehole antennas one next facing different way
-                            if ( j==0||j==3 ) {
-                                if ( k==0||k==1 ) {
+                        } else if (params.antenna_orientation == 1) { // borehole antennas one next facing different way
+                            if (j == 0 || j == 3) {
+                                if (k == 0 || k == 1) {
                                     stations[i].strings[j].antennas[k].orient = 0;
-                                }
-                                else {
+                                } else {
                                     stations[i].strings[j].antennas[k].orient = 1;
                                 }
-                            }
-                            else {
-                                if ( k==0||k==1 ) {
+                            } else {
+                                if (k == 0 || k == 1) {
                                     stations[i].strings[j].antennas[k].orient = 1;
-                                }
-                                else {
+                                } else {
                                     stations[i].strings[j].antennas[k].orient = 0;
                                 }
                             }
-                            
-                        }// end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
+
+                        } // end facing different. I know it only works with 4 strings, 4 antennas on each strings but couldn't find a better way than this. -Eugene
                     }
                 }
             } // end if bore hole antenna layout = 3 (where VHHH way)
-            
-            
-            
-            
-            
-            
-            
+
             //
             // set surface antenna postions
-            stations[i].surfaces[0].SetX( stations[i].GetX() + (R_surface * cos(PI/3.)) );
-            stations[i].surfaces[0].SetY( stations[i].GetY() + (R_surface * sin(PI/3.)) );
-            
-            stations[i].surfaces[1].SetX( stations[i].GetX() + (R_surface * cos(-PI/3.)) );
-            stations[i].surfaces[1].SetY( stations[i].GetY() + (R_surface * sin(-PI/3.)) );
-            
-            stations[i].surfaces[2].SetX( stations[i].GetX() + (R_surface * cos(PI)) );
-            //            stations[i].surfaces[2].y = stations[i].y + (R_surface * sin(PI));
-            stations[i].surfaces[2].SetY( stations[i].GetY() );
-            
-            stations[i].surfaces[3].SetX( stations[i].GetX() );
-            stations[i].surfaces[3].SetY( stations[i].GetY() );
+            stations[i].surfaces[0].SetX(stations[i].GetX() + (R_surface * cos(PI / 3.)));
+            stations[i].surfaces[0].SetY(stations[i].GetY() + (R_surface * sin(PI / 3.)));
 
+            stations[i].surfaces[1].SetX(stations[i].GetX() + (R_surface * cos(-PI / 3.)));
+            stations[i].surfaces[1].SetY(stations[i].GetY() + (R_surface * sin(-PI / 3.)));
+
+            stations[i].surfaces[2].SetX(stations[i].GetX() + (R_surface * cos(PI)));
+            //            stations[i].surfaces[2].y = stations[i].y + (R_surface * sin(PI));
+            stations[i].surfaces[2].SetY(stations[i].GetY());
+
+            stations[i].surfaces[3].SetX(stations[i].GetX());
+            stations[i].surfaces[3].SetY(stations[i].GetY());
 
             stations[i].number_of_antennas = params.number_of_strings_station * params.number_of_antennas_string;
-            
-        }// loop over stations i
-        
-        
+
+        } // loop over stations i
+
         // for idealized geometry, number of antennas in a station is constant
         max_number_of_antennas_station = params.number_of_strings_station * params.number_of_antennas_string;
-        
 
-        
+        ReadAllAntennaGains(settings1);
 
-	ReadAllAntennaGains(settings1);
-
-	//	if (settings1->NOISE==2){
-	ReadNoiseFigure("./data/ARA02_noiseFig.txt", settings1);
-	  //	}
+        //	if (settings1->NOISE==2){
+        ReadNoiseFigure("./data/ARA02_noiseFig.txt", settings1);
+        //	}
 
         ReadFilter("./data/filter.csv", settings1);
         // read preamp gain file!!
@@ -1476,282 +1226,491 @@ Detector::Detector(Settings *settings1, IceModel *icesurface, string setupfile) 
         // read FOAM gain file!!
         ReadFOAM("./data/FOAM.csv", settings1);
         // read gain offset for chs file!!
-        ReadGainOffset_TestBed("./data/preamp_ch_gain_offset.csv", settings1);// only TestBed for now
+        ReadGainOffset_TestBed("./data/preamp_ch_gain_offset.csv", settings1); // only TestBed for now
         // read threshold offset for chs file!!
-        ReadThresOffset_TestBed("./data/threshold_offset.csv", settings1);// only TestBed for now
-	// read threshold values for chs file
-	ReadThres_TestBed("./data/thresholds_TB.csv", settings1);// only TestBed for now
+        ReadThresOffset_TestBed("./data/threshold_offset.csv", settings1); // only TestBed for now
+        // read threshold values for chs file
+        ReadThres_TestBed("./data/thresholds_TB.csv", settings1); // only TestBed for now
         // read system temperature for chs file!!
 
-	cout << "check read temp testbed 2" << endl;
-       if (settings1->NOISE_CHANNEL_MODE != 0) {
-            ReadTemp_TestBed("./data/system_temperature.csv", settings1);// only TestBed for now
+        cout << "check read temp testbed 2" << endl;
+        if (settings1 -> NOISE_CHANNEL_MODE != 0) {
+            ReadTemp_TestBed("./data/system_temperature.csv", settings1); // only TestBed for now
         }
         // read total elec. chain response file!!
-        cout<<"start read elect chain"<<endl;
-        if(settings1->CUSTOM_ELECTRONICS==0){
+        cout << "start read elect chain" << endl;
+        if (settings1 -> CUSTOM_ELECTRONICS == 0) {
             //read the standard ARA electronics
-            cout<<"     Reading standard ARA electronics response"<<endl;
-             ReadElectChain("./data/ARA_Electronics_TotalGain_TwoFilters.txt", settings1);
+            cout << "     Reading standard ARA electronics response" << endl;
+            ReadElectChain("./data/ARA_Electronics_TotalGain_TwoFilters.txt", settings1);
             //ReadElectChain("./data/ARA_Electronics_TotalGainPhase.txt", settings1);
-        }
-        else if (settings1->CUSTOM_ELECTRONICS==1){
+        } else if (settings1 -> CUSTOM_ELECTRONICS == 1) {
             //read a custom user defined electronics gain
-            cout<<"     Reading custom electronics response"<<endl;
-             ReadElectChain("./data/custom_electronics.txt", settings1);
+            cout << "     Reading custom electronics response" << endl;
+            ReadElectChain("./data/custom_electronics.txt", settings1);
         }
-        
-        
-    }
-    
-    
+
+    } // if mode == 2
+
     /////////////////////////////////////////////////////////////////////////////////    
-    else if (mode == 3) {        //        cout<<"\n\tDector mode 3 : Testbed and eventual inclusion of a specific number of stations (less than 7 stations) !"<<endl;
+    else if (mode == 3) { //        cout<<"\n\tDector mode 3 : Testbed and eventual inclusion of a specific number of stations (less than 7 stations) !"<<endl;
         //        cout<<"We use "<<ARA_N_file.c_str()<<" as antenna info."<<endl;
-        
-        
+
         // initialize info
         params.number_of_stations = 1; //including Testbed
-        params.number_of_strings_station = 4;   // ARA-1 has 4 strings
+        params.number_of_strings_station = 4; // ARA-1 has 4 strings
         params.number_of_antennas_string = 4; // 4 antennas on each strings
         params.number_of_surfaces_station = 4;
         params.number_of_channels = 20;
-        
+
         //double core_x = 0.;
         //double core_y = 0.;
         params.core_x = 10000.;
         params.core_y = 10000.;
-        double R_string = 10.;  // all units are in meter
+        double R_string = 10.; // all units are in meter
         double R_surface = 60.;
         double z_max = 200.;
         double z_btw = 20.;
-        params.stations_per_side = 4;       // total 37 stations
-        params.station_spacing = 2000.;     // 2km spacing for borehole stations
-        params.antenna_orientation = 0;     // all antenna facing x
-        params.bore_hole_antenna_layout = settings1->BORE_HOLE_ANTENNA_LAYOUT;
+        params.stations_per_side = 4; // total 37 stations
+        params.station_spacing = 2000.; // 2km spacing for borehole stations
+        params.antenna_orientation = 0; // all antenna facing x
+        params.bore_hole_antenna_layout = settings1 -> BORE_HOLE_ANTENNA_LAYOUT;
         // finish initialization
         //
-        
 
-        
         // mode == 3 currently just use installed TestBed station geom information.
         // So don't need to read any more information
-        
+
         // Read new parameters if there are...
-        ifstream ARA_N( ARA_N_file.c_str() );
-        if ( ARA_N.is_open() ) {
-            while (ARA_N.good() ) {
-                getline (ARA_N, line);
-                
-                if (line[0] != "/"[0]) {
-                    label = line.substr(0, line.find_first_of("=") );
-                    
+        ifstream ARA_N(ARA_N_file.c_str());
+        if (ARA_N.is_open()) {
+            while (ARA_N.good()) {
+                getline(ARA_N, line);
+
+                if (line[0] != "/" [0]) {
+                    label = line.substr(0, line.find_first_of("="));
+
                     if (label == "core_x") {
-                        params.core_x = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read core_x"<<endl;
-                    }
-                    else if (label == "core_y") {
-                        params.core_y = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read core_y"<<endl;
-                    }
-                    else if (label == "R_string") {
-                        R_string = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read R_string"<<endl;
-                    }
-                    else if (label == "R_surface") {
-                        R_surface = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read R_surface"<<endl;
-                    }
-                    else if (label == "z_max") {
-                        z_max = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_max"<<endl;
-                    }
-                    else if (label == "z_btw") {
-                        z_btw = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_btw"<<endl;
-                    }
-                    else if (label == "number_of_stations") {
-                        params.number_of_stations = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read stations_per_side"<<endl;
-                    }
-                    else if (label == "station_spacing") {
-                        params.station_spacing = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read station_spacting"<<endl;
-                    }
-                    else if (label == "antenna_orientation") {
-                        params.antenna_orientation = atoi( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read antenna_orientation"<<endl;
+                        params.core_x = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read core_x" << endl;
+                    } else if (label == "core_y") {
+                        params.core_y = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read core_y" << endl;
+                    } else if (label == "R_string") {
+                        R_string = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read R_string" << endl;
+                    } else if (label == "R_surface") {
+                        R_surface = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read R_surface" << endl;
+                    } else if (label == "z_max") {
+                        z_max = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_max" << endl;
+                    } else if (label == "z_btw") {
+                        z_btw = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_btw" << endl;
+                    } else if (label == "number_of_stations") {
+                        params.number_of_stations = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read stations_per_side" << endl;
+                    } else if (label == "station_spacing") {
+                        params.station_spacing = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read station_spacting" << endl;
+                    } else if (label == "antenna_orientation") {
+                        params.antenna_orientation = atoi(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read antenna_orientation" << endl;
                     }
                 }
             }
             ARA_N.close();
         }
         // finished reading new parameters
-        
-        
-        
+
         params.number_of_antennas_string = 4;
 
-        
         // prepare vectors
         PrepareVectorsInstalled();
         // end prepare vectors
-        
+
         //
         // for ARA-37 (or more than 1 station case), need code for setting position for all 37 stations here!
         //
         int station_count = 0;
-        
-        for (int istation = 0; istation < (int)params.number_of_stations; istation++) {
-            if (station_count < (int)params.number_of_stations - 1) {
+
+        for (int istation = 0; istation < (int) params.number_of_stations; istation++) {
+            if (station_count < (int) params.number_of_stations - 1) {
                 //stations[station_count].x = core_x + (double)params.station_spacing * cos( (PI/3.) * (double)station_count );
                 //stations[station_count].y = core_y + (double)params.station_spacing * sin( (PI/3.) * (double)station_count );
-                stations[station_count].SetX( params.core_x + (double)params.station_spacing * cos( (PI/3.) * (double)station_count ) );
-                stations[station_count].SetY( params.core_y + (double)params.station_spacing * sin( (PI/3.) * (double)station_count ) );
+                stations[station_count].SetX(params.core_x + (double) params.station_spacing * cos((PI / 3.) * (double) station_count));
+                stations[station_count].SetY(params.core_y + (double) params.station_spacing * sin((PI / 3.) * (double) station_count));
                 station_count++;
-            }
-            else if (station_count < (int)params.number_of_stations) {
+            } else if (station_count < (int) params.number_of_stations) {
                 //stations[station_count].x = core_x;
                 //stations[station_count].y = core_y;
-                stations[station_count].SetX( params.core_x );
-                stations[station_count].SetY( params.core_y );
+                stations[station_count].SetX(params.core_x);
+                stations[station_count].SetY(params.core_y);
                 station_count++;
-            }
-            else {
-                cout<<"\n\tError, too many stations !"<<endl;
+            } else {
+                cout << "\n\tError, too many stations !" << endl;
             }
         }
         // finished setting all stations' position
-        
-        
+
         //        cout<<"total station_count : "<<station_count<<endl;
-        if (station_count != (int)params.number_of_stations) cout<<"\n\tError, station number not match !"<<endl;
-        
+        if (station_count != (int) params.number_of_stations) cout << "\n\tError, station number not match !" << endl;
+
         //
         // set antenna values from parameters
         // set station positions
         //cout << "READGEOM:" << settings1->READGEOM << endl;
-        
-#ifdef ARA_UTIL_EXISTS
+
+        #ifdef ARA_UTIL_EXISTS
         UseAntennaInfo(0, settings1);
-#endif
-//            UseAntennaInfo(1, settings1);
-        for (int i = 0; i < (int)params.number_of_stations; i++){
+        #endif
+        //            UseAntennaInfo(1, settings1);
+        for (int i = 0; i < (int) params.number_of_stations; i++) {
             stations[i].StationID = i;
-            if (settings1->USE_INSTALLED_TRIGGER_SETTINGS == 0){
+            if (settings1 -> USE_INSTALLED_TRIGGER_SETTINGS == 0) {
                 stations[i].NFOUR = 1024;
-                stations[i].TIMESTEP = 1./2.6*1.E-9;
+                stations[i].TIMESTEP = 1. / 2.6 * 1.E-9;
                 stations[i].TRIG_WINDOW = 2.5E-7;
-                stations[i].DATA_BIN_SIZE = settings1->DATA_BIN_SIZE;
-            }
-            else if (settings1->USE_INSTALLED_TRIGGER_SETTINGS == 1){
-                if (stations[i].StationID == 0){
+                stations[i].DATA_BIN_SIZE = settings1 -> DATA_BIN_SIZE;
+            } else if (settings1 -> USE_INSTALLED_TRIGGER_SETTINGS == 1) {
+                if (stations[i].StationID == 0) {
                     stations[i].NFOUR = 1024;
-                    stations[i].TIMESTEP = 1./2.6*1.E-9;
+                    stations[i].TIMESTEP = 1. / 2.6 * 1.E-9;
                     stations[i].TRIG_WINDOW = 2.5E-7;
-                    stations[i].DATA_BIN_SIZE = settings1->DATA_BIN_SIZE;
+                    stations[i].DATA_BIN_SIZE = settings1 -> DATA_BIN_SIZE;
                 }
-               if (stations[i].StationID == 1){
+                if (stations[i].StationID == 1) {
                     stations[i].NFOUR = 1024;
-                    stations[i].TIMESTEP = 1./2.6*1.E-9;
+                    stations[i].TIMESTEP = 1. / 2.6 * 1.E-9;
                     stations[i].TRIG_WINDOW = 2.5E-7;
-                    stations[i].DATA_BIN_SIZE = settings1->DATA_BIN_SIZE;
+                    stations[i].DATA_BIN_SIZE = settings1 -> DATA_BIN_SIZE;
                 }
             }
         }
-        
+
         params.number_of_antennas = 0;
 
-            cout<<"DETECTOR=3 TB station geom info"<<endl;
-        
-            for (int j = 0; j < stations[0].strings.size(); j++){
-                for (int k = 0; k < stations[0].strings[j].antennas.size(); k++){
-                    
-                     cout <<
-                     "DetectorStation2:string:antenna:X:Y:Z:chno :: " <<
-                     j<< " : " <<
-                     k<< " : " <<
-                     stations[0].strings[j].antennas[k].GetX() << " : " <<
-                     stations[0].strings[j].antennas[k].GetY() << " : " <<
-                     stations[0].strings[j].antennas[k].GetZ() << " : \t" <<
-                     //GetChannelfromStringAntenna ( 0, j, k)<<
-                     GetChannelfromStringAntenna ( 0, j, k, settings1)<<
-                     endl;
+        cout << "DETECTOR=3 TB station geom info" << endl;
 
-                     params.number_of_antennas++;
+        for (int j = 0; j < stations[0].strings.size(); j++) {
+            for (int k = 0; k < stations[0].strings[j].antennas.size(); k++) {
+
+                cout <<
+                    "DetectorStation2:string:antenna:X:Y:Z:chno :: " <<
+                    j << " : " <<
+                    k << " : " <<
+                    stations[0].strings[j].antennas[k].GetX() << " : " <<
+                    stations[0].strings[j].antennas[k].GetY() << " : " <<
+                    stations[0].strings[j].antennas[k].GetZ() << " : \t" <<
+                    //GetChannelfromStringAntenna ( 0, j, k)<<
+                    GetChannelfromStringAntenna(0, j, k, settings1) <<
+                    endl;
+
+                params.number_of_antennas++;
+            }
+        }
+
+        cout << "after FlattoEarth, station0 location" << endl;
+        for (int j = 0; j < stations[0].strings.size(); j++) {
+            for (int k = 0; k < stations[0].strings[j].antennas.size(); k++) {
+
+                cout <<
+                    "Detector:station:string:antenna:X:Y:Z:R:Theta:Phi:: " <<
+                    "0" << " : " <<
+                    j << " : " <<
+                    k << " : " <<
+                    stations[0].strings[j].antennas[k].GetX() << " : " <<
+                    stations[0].strings[j].antennas[k].GetY() << " : " <<
+                    stations[0].strings[j].antennas[k].GetZ() << " : " <<
+                    stations[0].strings[j].antennas[k].R() << " : " <<
+                    stations[0].strings[j].antennas[k].Theta() << " : " <<
+                    stations[0].strings[j].antennas[k].Phi() << " : " <<
+                    icesurface -> Surface(stations[0].strings[j].antennas[k].Lon(), stations[0].strings[j].antennas[k].Lat()) << " : " <<
+                    //             icesurface->Surface(stations[0].strings[j].antennas[k].Lat(), stations[0].strings[j].antennas[k].Lon()) << " : " <<
+                    endl;
+
+            }
+        }
+
+        int antenna_count = 0;
+        max_number_of_antennas_station = 0;
+        // for non-idealized geometry, it's better to actually count number of stations
+        for (int i = 0; i < (int)(stations.size()); i++) {
+
+            antenna_count = 0;
+            for (int j = 0; j < (int)(stations[i].strings.size()); j++) {
+                for (int k = 0; k < (int)(stations[i].strings[j].antennas.size()); k++) {
+                    antenna_count++;
                 }
             }
-        
+            stations[i].number_of_antennas = antenna_count;
 
-
-
-            cout<<"after FlattoEarth, station0 location"<<endl;
-    for (int j = 0; j < stations[0].strings.size(); j++){
-        for (int k = 0; k < stations[0].strings[j].antennas.size(); k++){
-
-             cout <<
-             "Detector:station:string:antenna:X:Y:Z:R:Theta:Phi:: " <<
-             "0" << " : " <<
-             j<< " : " <<
-             k<< " : " <<
-             stations[0].strings[j].antennas[k].GetX() << " : " <<
-             stations[0].strings[j].antennas[k].GetY() << " : " <<
-             stations[0].strings[j].antennas[k].GetZ() << " : " <<
-             stations[0].strings[j].antennas[k].R() << " : " <<
-             stations[0].strings[j].antennas[k].Theta() << " : " <<
-             stations[0].strings[j].antennas[k].Phi() << " : " <<
-             icesurface->Surface(stations[0].strings[j].antennas[k].Lon(), stations[0].strings[j].antennas[k].Lat()) << " : " <<
-//             icesurface->Surface(stations[0].strings[j].antennas[k].Lat(), stations[0].strings[j].antennas[k].Lon()) << " : " <<
-             endl;
-                 
-                     
+            if (max_number_of_antennas_station < antenna_count) max_number_of_antennas_station = antenna_count;
         }
-    }
 
+        ReadAllAntennaGains(settings1);
 
+        ReadNoiseFigure("./data/ARA02_noiseFig.txt", settings1);
 
-            int antenna_count = 0;
-            max_number_of_antennas_station = 0;
-            // for non-idealized geometry, it's better to actually count number of stations
-            for (int i=0; i<(int)(stations.size()); i++) {
-            
-                antenna_count = 0;
-                for (int j=0; j<(int)(stations[i].strings.size()); j++) {
-                    for (int k=0; k<(int)(stations[i].strings[j].antennas.size()); k++) {
-                        antenna_count++;
+        // read filter file!!
+        ReadFilter("./data/filter.csv", settings1);
+        // read preamp gain file!!
+        ReadPreamp("./data/preamp.csv", settings1);
+        // read FOAM gain file!!
+        ReadFOAM("./data/FOAM.csv", settings1);
+
+        if (settings1 -> NOISE == 1) {
+            // read Rayleigh fit for freq range, bh channels
+            ReadRayleighFit_TestBed("data/RayleighFit_TB.csv", settings1); // read and save RFCM gain
+        }
+
+        if (settings1 -> USE_TESTBED_RFCM_ON == 1) {
+            // read RFCM gain file!! (measured value in ICL)
+            ReadRFCM_TestBed("data/TestBed_RFCM/R1C1.csv", settings1); // read and save RFCM gain for ch1
+            ReadRFCM_TestBed("data/TestBed_RFCM/R1C2.csv", settings1); // read and save RFCM gain for ch2
+            ReadRFCM_TestBed("data/TestBed_RFCM/R1C3.csv", settings1); // read and save RFCM gain for ch3
+            ReadRFCM_TestBed("data/TestBed_RFCM/R1C4.csv", settings1); // read and save RFCM gain for ch4
+            ReadRFCM_TestBed("data/TestBed_RFCM/R2C5.csv", settings1); // read and save RFCM gain for ch5
+            ReadRFCM_TestBed("data/TestBed_RFCM/R2C6.csv", settings1); // read and save RFCM gain for ch6
+            ReadRFCM_TestBed("data/TestBed_RFCM/R2C7.csv", settings1); // read and save RFCM gain for ch7
+            ReadRFCM_TestBed("data/TestBed_RFCM/R2C8.csv", settings1); // read and save RFCM gain for ch8
+            ReadRFCM_TestBed("data/TestBed_RFCM/R3C9.csv", settings1); // read and save RFCM gain for ch9
+            ReadRFCM_TestBed("data/TestBed_RFCM/R3C10.csv", settings1); // read and save RFCM gain for ch10
+            ReadRFCM_TestBed("data/TestBed_RFCM/R3C11.csv", settings1); // read and save RFCM gain for ch11
+            ReadRFCM_TestBed("data/TestBed_RFCM/R3C12.csv", settings1); // read and save RFCM gain for ch12
+            ReadRFCM_TestBed("data/TestBed_RFCM/R4C13.csv", settings1); // read and save RFCM gain for ch13
+            ReadRFCM_TestBed("data/TestBed_RFCM/R4C14.csv", settings1); // read and save RFCM gain for ch14
+            ReadRFCM_TestBed("data/TestBed_RFCM/R4C15.csv", settings1); // read and save RFCM gain for ch15
+            ReadRFCM_TestBed("data/TestBed_RFCM/R4C16.csv", settings1); // read and save RFCM gain for ch16
+        }
+
+        // read gain offset for chs file!!
+        ReadGainOffset_TestBed("./data/preamp_ch_gain_offset.csv", settings1); // only TestBed for now
+        // read threshold offset for chs file!!
+        ReadThresOffset_TestBed("./data/threshold_offset.csv", settings1); // only TestBed for now
+        // read threshold values for chs file
+        ReadThres_TestBed("./data/thresholds_TB.csv", settings1); // only TestBed for now
+        // read system temperature for chs file!!
+        cout << "check read temp testbed 3" << endl;
+        if (settings1 -> NOISE_CHANNEL_MODE != 0) {
+            ReadTemp_TestBed("./data/system_temperature.csv", settings1); // only TestBed for now
+        }
+
+        // read total elec. chain response file!!
+        cout << "start read elect chain" << endl;
+        if (settings1 -> CUSTOM_ELECTRONICS == 0) {
+            //read the standard ARA electronics
+            cout << "     Reading standard ARA electronics response" << endl;
+            ReadElectChain("./data/ARA_Electronics_TotalGain_TwoFilters.txt", settings1);
+            //ReadElectChain("./data/ARA_Electronics_TotalGainPhase.txt", settings1);
+        } else if (settings1 -> CUSTOM_ELECTRONICS == 1) {
+            //read a custom user defined electronics gain
+            cout << "     Reading custom electronics response" << endl;
+            ReadElectChain("./data/custom_electronics.txt", settings1);
+        }
+        cout << "done read elect chain" << endl;
+
+        // if calpulser case
+        if (settings1 -> CALPULSER_ON > 0) {
+            // read TestBed Calpulser waveform measured (before pulser)
+            ReadCalPulserWF("./data/CalPulserWF.txt", settings1);
+        }
+
+    } // if mode == 3
+    
+    else if (mode == 4) {
+        // cout<<"\n\tDector mode 4 : Single installed station determined by DETECTOR_STATION !"<<endl;
+
+        // initialize info
+        params.number_of_stations = 1; //including Testbed
+        params.number_of_strings_station = 4; // ARA-1 has 4 strings
+        params.number_of_antennas_string = 4; // 4 antennas on each strings
+        params.number_of_surfaces_station = 4;
+        params.number_of_channels = 20;
+
+        params.core_x = 10000.;
+        params.core_y = 10000.;
+        double R_string = 10.; // all units are in meter
+        double R_surface = 60.;
+        double z_max = 200.;
+        double z_btw = 20.;
+        params.stations_per_side = 4; // total 37 stations
+        params.station_spacing = 2000.; // 2km spacing for borehole stations
+        params.antenna_orientation = 0; // all antenna facing x
+        params.bore_hole_antenna_layout = settings1 -> BORE_HOLE_ANTENNA_LAYOUT;
+        // finish initialization
+
+        // Read new parameters if there are...
+        ifstream ARA_N(ARA_N_file.c_str());
+        if (ARA_N.is_open()) {
+            while (ARA_N.good()) {
+                getline(ARA_N, line);
+
+                if (line[0] != "/" [0]) {
+                    label = line.substr(0, line.find_first_of("="));
+
+                    if (label == "core_x") {
+                        params.core_x = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read core_x" << endl;
+                    } else if (label == "core_y") {
+                        params.core_y = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read core_y" << endl;
+                    } else if (label == "R_string") {
+                        R_string = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read R_string" << endl;
+                    } else if (label == "R_surface") {
+                        R_surface = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read R_surface" << endl;
+                    } else if (label == "z_max") {
+                        z_max = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_max" << endl;
+                    } else if (label == "z_btw") {
+                        z_btw = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read z_btw" << endl;
+                    } else if (label == "number_of_stations") {
+                        params.number_of_stations = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read stations_per_side" << endl;
+                    } else if (label == "station_spacing") {
+                        params.station_spacing = atof(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read station_spacting" << endl;
+                    } else if (label == "antenna_orientation") {
+                        params.antenna_orientation = atoi(line.substr(line.find_first_of("=") + 1).c_str());
+                        cout << "read antenna_orientation" << endl;
                     }
                 }
-                stations[i].number_of_antennas = antenna_count;
-
-                if (max_number_of_antennas_station < antenna_count) max_number_of_antennas_station = antenna_count;
             }
+            ARA_N.close();
+        }
+        // finished reading new parameters
+
+        params.number_of_antennas_string = 4;
+
+        PrepareVectorsInstalled(settings1 -> DETECTOR_STATION);
+
+        int station_count = 0;
+
+        stations[0].SetX(params.core_x);
+        stations[0].SetY(params.core_y);
+
+        // cout<<"total station_count : "<<station_count<<endl;
+        if (station_count != (int) params.number_of_stations) cout << "\n\tError, station number not match !" << endl;
 
 
-            
-            
+        #ifdef ARA_UTIL_EXISTS
+        ImportStationInfo(settings1, 0, settings1 -> DETECTOR_STATION);
+        #endif
+
+        std::cout << "Imported Station info" << std::endl;
+
+        int stationID = settings1 -> DETECTOR_STATION;
 
 
+        for (int i = 0; i < (int) params.number_of_stations; i++) {
+            stations[i].StationID = settings1 -> DETECTOR_STATION;
+            if (settings1 -> USE_INSTALLED_TRIGGER_SETTINGS == 0) {
+                stations[i].NFOUR = 1024;
+                stations[i].TIMESTEP = 1. / 2.6 * 1.E-9;
+                stations[i].TRIG_WINDOW = 2.5E-7;
+                stations[i].DATA_BIN_SIZE = settings1 -> DATA_BIN_SIZE;
+            } else if (settings1 -> USE_INSTALLED_TRIGGER_SETTINGS == 1) {
+                if (stations[i].StationID == 0) {
+                    stations[i].NFOUR = 1024;
+                    stations[i].TIMESTEP = 1. / 2.6 * 1.E-9;
+                    stations[i].TRIG_WINDOW = 2.5E-7;
+                    stations[i].DATA_BIN_SIZE = settings1 -> DATA_BIN_SIZE;
+                }
+                if (stations[i].StationID == 1) {
+                    stations[i].NFOUR = 1024;
+                    stations[i].TIMESTEP = 1. / 2.6 * 1.E-9;
+                    stations[i].TRIG_WINDOW = 2.5E-7;
+                    stations[i].DATA_BIN_SIZE = settings1 -> DATA_BIN_SIZE;
+                }
+            }
+        }
 
-	    ReadAllAntennaGains(settings1);
-	    
+        params.number_of_antennas = 0;
 
-	    ReadNoiseFigure("./data/ARA02_noiseFig.txt", settings1);
-	      
-            // read filter file!!
-            ReadFilter("./data/filter.csv", settings1);
-            // read preamp gain file!!
-            ReadPreamp("./data/preamp.csv", settings1);
-            // read FOAM gain file!!
-            ReadFOAM("./data/FOAM.csv", settings1);
+        cout << "DETECTOR=4 imported station geom info" << endl;
 
+        for (int j = 0; j < stations[0].strings.size(); j++) {
+            for (int k = 0; k < stations[0].strings[j].antennas.size(); k++) {
 
+                cout <<
+                    "DetectorStation2:string:antenna:X:Y:Z:chno :: " <<
+                    j << " : " <<
+                    k << " : " <<
+                    stations[0].strings[j].antennas[k].GetX() << " : " <<
+                    stations[0].strings[j].antennas[k].GetY() << " : " <<
+                    stations[0].strings[j].antennas[k].GetZ() << " : \t" <<
+                    GetChannelfromStringAntenna(stationID, j, k, settings1) <<
+                    endl;
 
-            if ( settings1->NOISE==1) {
+                params.number_of_antennas++;
+            }
+        }
+
+        cout << "after FlattoEarth, station0 location" << endl;
+        for (int j = 0; j < stations[0].strings.size(); j++) {
+            for (int k = 0; k < stations[0].strings[j].antennas.size(); k++) {
+
+                cout <<
+                    "Detector:station:string:antenna:X:Y:Z:R:Theta:Phi:: " <<
+                    "0" << " : " <<
+                    j << " : " <<
+                    k << " : " <<
+                    stations[0].strings[j].antennas[k].GetX() << " : " <<
+                    stations[0].strings[j].antennas[k].GetY() << " : " <<
+                    stations[0].strings[j].antennas[k].GetZ() << " : " <<
+                    stations[0].strings[j].antennas[k].R() << " : " <<
+                    stations[0].strings[j].antennas[k].Theta() << " : " <<
+                    stations[0].strings[j].antennas[k].Phi() << " : " <<
+                    icesurface -> Surface(stations[0].strings[j].antennas[k].Lon(), stations[0].strings[j].antennas[k].Lat()) << " : " <<
+                    endl;
+            }
+        }
+
+        int antenna_count = 0;
+        max_number_of_antennas_station = 0;
+        // for non-idealized geometry, it's better to actually count number of stations
+        for (int i = 0; i < (int)(stations.size()); i++) {
+
+            antenna_count = 0;
+            for (int j = 0; j < (int)(stations[i].strings.size()); j++) {
+                for (int k = 0; k < (int)(stations[i].strings[j].antennas.size()); k++) {
+                    antenna_count++;
+                }
+            }
+            stations[i].number_of_antennas = antenna_count;
+
+            if (max_number_of_antennas_station < antenna_count) max_number_of_antennas_station = antenna_count;
+        }
+
+        ReadAllAntennaGains(settings1);
+
+        //	    if (settings1->NOISE == 2){
+        //Read the noise figures
+        ReadNoiseFigure("./data/ARA02_noiseFig.txt", settings1);
+        //	    }
+
+        // read filter file!!
+        ReadFilter("./data/filter.csv", settings1);
+        // read preamp gain file!!
+        ReadPreamp("./data/preamp.csv", settings1);
+        // read FOAM gain file!!
+        ReadFOAM("./data/FOAM.csv", settings1);
+
+        if (settings1 -> NOISE_CHANNEL_MODE != 0) {
+            ReadTemp_TestBed("./data/system_temperature.csv", settings1); // only TestBed for now
+        }
+
+        if (settings1 -> DETECTOR_STATION == 0) {
+            if (settings1 -> NOISE == 1) {
                 // read Rayleigh fit for freq range, bh channels
                 ReadRayleighFit_TestBed("data/RayleighFit_TB.csv", settings1); // read and save RFCM gain
             }
 
-            if ( settings1->USE_TESTBED_RFCM_ON==1) {
+            if (settings1 -> USE_TESTBED_RFCM_ON == 1) {
                 // read RFCM gain file!! (measured value in ICL)
                 ReadRFCM_TestBed("data/TestBed_RFCM/R1C1.csv", settings1); // read and save RFCM gain for ch1
                 ReadRFCM_TestBed("data/TestBed_RFCM/R1C2.csv", settings1); // read and save RFCM gain for ch2
@@ -1772,361 +1731,62 @@ Detector::Detector(Settings *settings1, IceModel *icesurface, string setupfile) 
             }
 
             // read gain offset for chs file!!
-            ReadGainOffset_TestBed("./data/preamp_ch_gain_offset.csv", settings1);// only TestBed for now
+            ReadGainOffset_TestBed("./data/preamp_ch_gain_offset.csv", settings1); // only TestBed for now
             // read threshold offset for chs file!!
-            ReadThresOffset_TestBed("./data/threshold_offset.csv", settings1);// only TestBed for now
-	    // read threshold values for chs file
-	    ReadThres_TestBed("./data/thresholds_TB.csv", settings1);// only TestBed for now
+            ReadThresOffset_TestBed("./data/threshold_offset.csv", settings1); // only TestBed for now
+            // read threshold values for chs file
+            ReadThres_TestBed("./data/thresholds_TB.csv", settings1); // only TestBed for now
             // read system temperature for chs file!!
-	cout << "check read temp testbed 3" << endl;
-            if (settings1->NOISE_CHANNEL_MODE!=0) {
-                ReadTemp_TestBed("./data/system_temperature.csv", settings1);// only TestBed for now
+            cout << "check read temp testbed 4" << endl;
+            if (settings1 -> NOISE_CHANNEL_MODE != 0) {
+                ReadTemp_TestBed("./data/system_temperature.csv", settings1); // only TestBed for now
             }
-	    
-            // read total elec. chain response file!!
-	    cout<<"start read elect chain"<<endl;
-        if(settings1->CUSTOM_ELECTRONICS==0){
-            //read the standard ARA electronics
-            cout<<"     Reading standard ARA electronics response"<<endl;
-             ReadElectChain("./data/ARA_Electronics_TotalGain_TwoFilters.txt", settings1);
-            //ReadElectChain("./data/ARA_Electronics_TotalGainPhase.txt", settings1);
         }
-        else if (settings1->CUSTOM_ELECTRONICS==1){
-            //read a custom user defined electronics gain
-            cout<<"     Reading custom electronics response"<<endl;
-             ReadElectChain("./data/custom_electronics.txt", settings1);
-        }
-	    cout<<"done read elect chain"<<endl;
-	    
-
-	    
-	    // if calpulser case
-            if (settings1->CALPULSER_ON > 0) {
-	      // read TestBed Calpulser waveform measured (before pulser)
-	      ReadCalPulserWF("./data/CalPulserWF.txt", settings1);
-            }
-	    
-	    
-
-    }// if mode == 3
-
-    else if (mode == 4) {        
-      //        cout<<"\n\tDector mode 4 : Single installed station determined by DETECTOR_STATION !"<<endl;
-      //        cout<<"We use "<<ARA_N_file.c_str()<<" as antenna info."<<endl;
-        
-        
-        // initialize info
-        params.number_of_stations = 1; //including Testbed
-        params.number_of_strings_station = 4;   // ARA-1 has 4 strings
-        params.number_of_antennas_string = 4; // 4 antennas on each strings
-        params.number_of_surfaces_station = 4;
-        params.number_of_channels = 20;
-        
-        //double core_x = 0.;
-        //double core_y = 0.;
-        params.core_x = 10000.;
-        params.core_y = 10000.;
-        double R_string = 10.;  // all units are in meter
-        double R_surface = 60.;
-        double z_max = 200.;
-        double z_btw = 20.;
-        params.stations_per_side = 4;       // total 37 stations
-        params.station_spacing = 2000.;     // 2km spacing for borehole stations
-        params.antenna_orientation = 0;     // all antenna facing x
-        params.bore_hole_antenna_layout = settings1->BORE_HOLE_ANTENNA_LAYOUT;
-        // finish initialization
-        //
-
-        // mode == 4 currently just use installed TestBed station geom information.
-        // So don't need to read any more information
-        
-        // Read new parameters if there are...
-        ifstream ARA_N( ARA_N_file.c_str() );
-        if ( ARA_N.is_open() ) {
-            while (ARA_N.good() ) {
-                getline (ARA_N, line);
-                
-                if (line[0] != "/"[0]) {
-                    label = line.substr(0, line.find_first_of("=") );
-                    
-                    if (label == "core_x") {
-                        params.core_x = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read core_x"<<endl;
-                    }
-                    else if (label == "core_y") {
-                        params.core_y = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read core_y"<<endl;
-                    }
-                    else if (label == "R_string") {
-                        R_string = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read R_string"<<endl;
-                    }
-                    else if (label == "R_surface") {
-                        R_surface = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read R_surface"<<endl;
-                    }
-                    else if (label == "z_max") {
-                        z_max = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_max"<<endl;
-                    }
-                    else if (label == "z_btw") {
-                        z_btw = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read z_btw"<<endl;
-                    }
-                    else if (label == "number_of_stations") {
-                        params.number_of_stations = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read stations_per_side"<<endl;
-                    }
-                    else if (label == "station_spacing") {
-                        params.station_spacing = atof( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read station_spacting"<<endl;
-                    }
-                    else if (label == "antenna_orientation") {
-                        params.antenna_orientation = atoi( line.substr( line.find_first_of("=") + 1).c_str() );
-                        cout<<"read antenna_orientation"<<endl;
-                    }
-                }
-            }
-            ARA_N.close();
-        }
-        // finished reading new parameters
-        
-        params.number_of_antennas_string = 4;
-        
-        // prepare vectors
-        PrepareVectorsInstalled(settings1->DETECTOR_STATION);
-        // end prepare vectors
-        
-        //
-        // for ARA-37 (or more than 1 station case), need code for setting position for all 37 stations here!
-        //
-        int station_count = 0;
-
-
-	stations[0].SetX( params.core_x );
-	stations[0].SetY( params.core_y );
-
-        
-        //        cout<<"total station_count : "<<station_count<<endl;
-        if (station_count != (int)params.number_of_stations) cout<<"\n\tError, station number not match !"<<endl;
-        
-        //
-        // set antenna values from parameters
-        // set station positions
-        //cout << "READGEOM:" << settings1->READGEOM << endl;
-        
-#ifdef ARA_UTIL_EXISTS
-        ImportStationInfo(settings1, 0, settings1->DETECTOR_STATION);
-#endif
-    std::cout<<"Imported Station info"<<std::endl;
-//            UseAntennaInfo(1, settings1);
-	int stationID = settings1->DETECTOR_STATION;
-    // std::cout<<"stationID"<<stationID<<std::endl;
-        for (int i = 0; i < (int)params.number_of_stations; i++){
-	  stations[i].StationID = settings1->DETECTOR_STATION;
-	  if (settings1->USE_INSTALLED_TRIGGER_SETTINGS == 0){
-	    stations[i].NFOUR = 1024;
-	    stations[i].TIMESTEP = 1./2.6*1.E-9;
-	    stations[i].TRIG_WINDOW = 2.5E-7;
-	    stations[i].DATA_BIN_SIZE = settings1->DATA_BIN_SIZE;
-	  }
-	  else if (settings1->USE_INSTALLED_TRIGGER_SETTINGS == 1){
-	    if (stations[i].StationID == 0){
-	      stations[i].NFOUR = 1024;
-	      stations[i].TIMESTEP = 1./2.6*1.E-9;
-	      stations[i].TRIG_WINDOW = 2.5E-7;
-	      stations[i].DATA_BIN_SIZE = settings1->DATA_BIN_SIZE;
-	    }
-	    if (stations[i].StationID == 1){
-	      stations[i].NFOUR = 1024;
-	      stations[i].TIMESTEP = 1./2.6*1.E-9;
-	      stations[i].TRIG_WINDOW = 2.5E-7;
-	      stations[i].DATA_BIN_SIZE = settings1->DATA_BIN_SIZE;
-	    }
-	  }
-        }
-        
-        params.number_of_antennas = 0;
-	
-	cout<<"DETECTOR=4 imported station geom info"<<endl;
-        
-	for (int j = 0; j < stations[0].strings.size(); j++){
-	  for (int k = 0; k < stations[0].strings[j].antennas.size(); k++){
-	    
-	    cout <<
-	      "DetectorStation2:string:antenna:X:Y:Z:chno :: " <<
-	      j<< " : " <<
-	      k<< " : " <<
-	      stations[0].strings[j].antennas[k].GetX() << " : " <<
-	      stations[0].strings[j].antennas[k].GetY() << " : " <<
-	      stations[0].strings[j].antennas[k].GetZ() << " : \t" <<
-	      //GetChannelfromStringAntenna ( 0, j, k)<<
-	      GetChannelfromStringAntenna ( stationID, j, k, settings1)<<
-	      endl;
-	    
-	    params.number_of_antennas++;
-	  }
-	}
-        
-
-
-
-	cout<<"after FlattoEarth, station0 location"<<endl;
-	for (int j = 0; j < stations[0].strings.size(); j++){
-	  for (int k = 0; k < stations[0].strings[j].antennas.size(); k++){
-	    
-	    cout <<
-             "Detector:station:string:antenna:X:Y:Z:R:Theta:Phi:: " <<
-             "0" << " : " <<
-             j<< " : " <<
-             k<< " : " <<
-             stations[0].strings[j].antennas[k].GetX() << " : " <<
-             stations[0].strings[j].antennas[k].GetY() << " : " <<
-             stations[0].strings[j].antennas[k].GetZ() << " : " <<
-             stations[0].strings[j].antennas[k].R() << " : " <<
-             stations[0].strings[j].antennas[k].Theta() << " : " <<
-             stations[0].strings[j].antennas[k].Phi() << " : " <<
-             icesurface->Surface(stations[0].strings[j].antennas[k].Lon(), stations[0].strings[j].antennas[k].Lat()) << " : " <<
-//             icesurface->Surface(stations[0].strings[j].antennas[k].Lat(), stations[0].strings[j].antennas[k].Lon()) << " : " <<
-             endl;
-                 
-                     
-        }
-	}
-
-
-
-            int antenna_count = 0;
-            max_number_of_antennas_station = 0;
-            // for non-idealized geometry, it's better to actually count number of stations
-            for (int i=0; i<(int)(stations.size()); i++) {
-            
-                antenna_count = 0;
-                for (int j=0; j<(int)(stations[i].strings.size()); j++) {
-                    for (int k=0; k<(int)(stations[i].strings[j].antennas.size()); k++) {
-                        antenna_count++;
-                    }
-                }
-                stations[i].number_of_antennas = antenna_count;
-
-                if (max_number_of_antennas_station < antenna_count) max_number_of_antennas_station = antenna_count;
-            }
-
-	    ReadAllAntennaGains(settings1);
-
-	    //	    if (settings1->NOISE == 2){
-	      //Read the noise figures
-	      ReadNoiseFigure("./data/ARA02_noiseFig.txt", settings1);
-	      //	    }
-
-            // read filter file!!
-            ReadFilter("./data/filter.csv", settings1);
-            // read preamp gain file!!
-            ReadPreamp("./data/preamp.csv", settings1);
-            // read FOAM gain file!!
-            ReadFOAM("./data/FOAM.csv", settings1);
-
-	    if (settings1->NOISE_CHANNEL_MODE!=0) {
-	      ReadTemp_TestBed("./data/system_temperature.csv", settings1);// only TestBed for now
-	    }
-	    
-
-	    if (settings1->DETECTOR_STATION == 0){
-	      if ( settings1->NOISE==1) {
-                // read Rayleigh fit for freq range, bh channels
-                ReadRayleighFit_TestBed("data/RayleighFit_TB.csv", settings1); // read and save RFCM gain
-	      }
-	      
-	      if ( settings1->USE_TESTBED_RFCM_ON==1) {
-                // read RFCM gain file!! (measured value in ICL)
-                ReadRFCM_TestBed("data/TestBed_RFCM/R1C1.csv", settings1); // read and save RFCM gain for ch1
-                ReadRFCM_TestBed("data/TestBed_RFCM/R1C2.csv", settings1); // read and save RFCM gain for ch2
-                ReadRFCM_TestBed("data/TestBed_RFCM/R1C3.csv", settings1); // read and save RFCM gain for ch3
-                ReadRFCM_TestBed("data/TestBed_RFCM/R1C4.csv", settings1); // read and save RFCM gain for ch4
-                ReadRFCM_TestBed("data/TestBed_RFCM/R2C5.csv", settings1); // read and save RFCM gain for ch5
-                ReadRFCM_TestBed("data/TestBed_RFCM/R2C6.csv", settings1); // read and save RFCM gain for ch6
-                ReadRFCM_TestBed("data/TestBed_RFCM/R2C7.csv", settings1); // read and save RFCM gain for ch7
-                ReadRFCM_TestBed("data/TestBed_RFCM/R2C8.csv", settings1); // read and save RFCM gain for ch8
-                ReadRFCM_TestBed("data/TestBed_RFCM/R3C9.csv", settings1); // read and save RFCM gain for ch9
-                ReadRFCM_TestBed("data/TestBed_RFCM/R3C10.csv", settings1); // read and save RFCM gain for ch10
-                ReadRFCM_TestBed("data/TestBed_RFCM/R3C11.csv", settings1); // read and save RFCM gain for ch11
-                ReadRFCM_TestBed("data/TestBed_RFCM/R3C12.csv", settings1); // read and save RFCM gain for ch12
-                ReadRFCM_TestBed("data/TestBed_RFCM/R4C13.csv", settings1); // read and save RFCM gain for ch13
-                ReadRFCM_TestBed("data/TestBed_RFCM/R4C14.csv", settings1); // read and save RFCM gain for ch14
-                ReadRFCM_TestBed("data/TestBed_RFCM/R4C15.csv", settings1); // read and save RFCM gain for ch15
-                ReadRFCM_TestBed("data/TestBed_RFCM/R4C16.csv", settings1); // read and save RFCM gain for ch16
-	      }
-
-	      // read gain offset for chs file!!
-	      ReadGainOffset_TestBed("./data/preamp_ch_gain_offset.csv", settings1);// only TestBed for now
-	      // read threshold offset for chs file!!
-	      ReadThresOffset_TestBed("./data/threshold_offset.csv", settings1);// only TestBed for now
-	      // read threshold values for chs file
-	      ReadThres_TestBed("./data/thresholds_TB.csv", settings1);// only TestBed for now
-	      // read system temperature for chs file!!
-	      cout << "check read temp testbed 4" << endl;
-	      if (settings1->NOISE_CHANNEL_MODE!=0) {
-		ReadTemp_TestBed("./data/system_temperature.csv", settings1);// only TestBed for now
-	      }
-	    }
-        if(settings1->DETECTOR_STATION>0){            
+        if (settings1 -> DETECTOR_STATION > 0) {
             // simulating a deep station (not testbed, DETECTOR_STATION==0)
-            
+
             // if simuating detector specific noise, need to load those files
-            if(settings1->NOISE==1){
+            if (settings1 -> NOISE == 1) {
                 char the_rayleigh_filename[500];
-                sprintf(the_rayleigh_filename, "./data/noise/sigmavsfreq_A_%d_config_%d.csv", 
-                    settings1->DETECTOR_STATION,  settings1->DETECTOR_STATION_LIVETIME_CONFIG);
+                sprintf(the_rayleigh_filename, "./data/noise/sigmavsfreq_A_%d_config_%d.csv",
+                    settings1 -> DETECTOR_STATION, settings1 -> DETECTOR_STATION_LIVETIME_CONFIG);
                 ReadRayleighFit_DeepStation(std::string(the_rayleigh_filename), settings1);
             }
         }
-        
-            // read total elec. chain response file!!
-	    cout<<"start read elect chain"<<endl;
-        if(settings1->CUSTOM_ELECTRONICS==0){
+
+        // read total elec. chain response file!!
+        cout << "start read elect chain" << endl;
+        if (settings1 -> CUSTOM_ELECTRONICS == 0) {
             //read the standard ARA electronics
-            cout<<"     Reading standard ARA electronics response"<<endl;
-             ReadElectChain("./data/ARA_Electronics_TotalGain_TwoFilters.txt", settings1);
+            cout << "     Reading standard ARA electronics response" << endl;
+            ReadElectChain("./data/ARA_Electronics_TotalGain_TwoFilters.txt", settings1);
             //ReadElectChain("./data/ARA_Electronics_TotalGainPhase.txt", settings1);
-        }
-        else if (settings1->CUSTOM_ELECTRONICS==1){
+        } else if (settings1 -> CUSTOM_ELECTRONICS == 1) {
             //read a custom user defined electronics gain
-            cout<<"     Reading custom electronics response"<<endl;
-             ReadElectChain("./data/custom_electronics.txt", settings1);
+            cout << "     Reading custom electronics response" << endl;
+            ReadElectChain("./data/custom_electronics.txt", settings1);
         }
-	    cout<<"done read elect chain"<<endl;
-    
-	    // if calpulser case
-            if (settings1->CALPULSER_ON > 0) {
-	      // read TestBed Calpulser waveform measured (before pulser)
-	      ReadCalPulserWF("./data/CalPulserWF.txt", settings1);
-            }
-	    
+        cout << "done read elect chain" << endl;
 
+        // if calpulser case
+        if (settings1 -> CALPULSER_ON > 0) {
+            // read TestBed Calpulser waveform measured (before pulser)
+            ReadCalPulserWF("./data/CalPulserWF.txt", settings1);
+        }
 
-    }// if mode == 4
-
-
-
+    } // if mode == 4
 
     // add additional depth if it's on
     AddAdditional_Depth(settings1);
 
-    
-            
     // change coordinate from flat surface to curved Earth surface
     //FlattoEarth_ARA(icesurface);
-    FlattoEarth_ARA_sharesurface(icesurface);   // this one will share the lowest surface at each station.
+    FlattoEarth_ARA_sharesurface(icesurface); // this one will share the lowest surface at each station.
 
-    
-    
-    //cout<<"done settings detectors, gain, filters"<<endl;
-    
-    getDiodeModel(settings1);    // set diode_real and fdiode_real values.
-    
-    
-    
+    getDiodeModel(settings1); // set diode_real and fdiode_real values.
+
 }
+
 
 inline void Detector::ReadAllAntennaGains(Settings *settings1){
     if (settings1->ANTENNA_MODE == 0){

--- a/Settings.cc
+++ b/Settings.cc
@@ -971,22 +971,7 @@ int Settings::CheckCompatibilitiesSettings() {
 	    if (DETECTOR_STATION <0 || DETECTOR_STATION >= NUM_INSTALLED_STATIONS){
 	        cerr << "DETECTOR_STATION is not set to a valid station number" << endl;
 	        num_err++;
-	    }
-        // if(DETECTOR_STATION_LIVETIME_CONFIG>-1){
-        //     if((int)DETECTOR_STATION==2 || (int)DETECTOR_STATION==3){
-        //         cerr<<"DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<endl;
-        //         if(DETECTOR_STATION_LIVETIME_CONFIG>5 || DETECTOR_STATION_LIVETIME_CONFIG<1){
-        //             cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<" but there are only five expected configurations"<<endl;
-        //             num_err++;
-        //         }
-        //     }
-        //     else{
-        //         cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<" but DETECTOR_STATION is "<<DETECTOR_STATION<<endl;
-        //         cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is only valid for A2 and A3 "<<endl;
-        //         num_err++;
-        //     }
-        // }
-		
+	    }	
       }
     }
 

--- a/Settings.cc
+++ b/Settings.cc
@@ -181,7 +181,7 @@ outputdir="outputs"; // directory where outputs go
     
     USE_INSTALLED_TRIGGER_SETTINGS = 0; // default : 0 - use idealized settings for the trigger
     
-    NUM_INSTALLED_STATIONS = 4;
+    NUM_INSTALLED_STATIONS = 6;
 
     CALPUL_OFFCONE_ANGLE = 35.;
 
@@ -935,14 +935,13 @@ int Settings::CheckCompatibilitiesSettings() {
         cerr<<"TRIG_ONLY_LOW_CH_ON=1 doesn't work with DETECTOR=3!"<<endl;
         num_err++;
     }
-
     if (DATA_LIKE_OUTPUT != 0 && (DETECTOR==0 || DETECTOR==1 || DETECTOR==2)) {
         cerr<<"DATA_LIKE_OUTPUT=1,2 doesn't work with DETECTOR=0,1,2"<<endl;
         cerr<<"DATA_LIKE_OUTPUT controls data-like output into UsefulAtriStationEvent format; without a real station selected (using DETECTOR==3,4), the mapping to the data-like output will not function correctly"<<endl;
         num_err++;
     }
 
-    if (DATA_LIKE_OUTPUT != 0 && (DETECTOR_STATION>3)) {
+    if (DATA_LIKE_OUTPUT != 0 && (DETECTOR_STATION>5)) {
         cerr<<"DATA_LIKE_OUTPUT=1,2 doesn't work with DETECTOR_STATION>3"<<endl;
         cerr<<"DATA_LIKE_OUTPUT controls data-like output into UsefulAtriStationEvent format; without a real station selected (using DETECTOR==3,4), the mapping to the data-like output will not function correctly"<<endl;
         num_err++;
@@ -973,20 +972,20 @@ int Settings::CheckCompatibilitiesSettings() {
 	        cerr << "DETECTOR_STATION is not set to a valid station number" << endl;
 	        num_err++;
 	    }
-        if(DETECTOR_STATION_LIVETIME_CONFIG>-1){
-            if((int)DETECTOR_STATION==2 || (int)DETECTOR_STATION==3){
-                cerr<<"DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<endl;
-                if(DETECTOR_STATION_LIVETIME_CONFIG>5 || DETECTOR_STATION_LIVETIME_CONFIG<1){
-                    cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<" but there are only five expected configurations"<<endl;
-                    num_err++;
-                }
-            }
-            else{
-                cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<" but DETECTOR_STATION is "<<DETECTOR_STATION<<endl;
-                cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is only valid for A2 and A3 "<<endl;
-                num_err++;
-            }
-        }
+        // if(DETECTOR_STATION_LIVETIME_CONFIG>-1){
+        //     if((int)DETECTOR_STATION==2 || (int)DETECTOR_STATION==3){
+        //         cerr<<"DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<endl;
+        //         if(DETECTOR_STATION_LIVETIME_CONFIG>5 || DETECTOR_STATION_LIVETIME_CONFIG<1){
+        //             cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<" but there are only five expected configurations"<<endl;
+        //             num_err++;
+        //         }
+        //     }
+        //     else{
+        //         cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<" but DETECTOR_STATION is "<<DETECTOR_STATION<<endl;
+        //         cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is only valid for A2 and A3 "<<endl;
+        //         num_err++;
+        //     }
+        // }
 		
       }
     }

--- a/log.txt
+++ b/log.txt
@@ -1717,3 +1717,5 @@ SetupInstalledStations to have the A4 and A5 geometry information.
 I also linted the main Detector function to fix a bunch of tabbing issues.
 This improved readability.
 
+There's also a minor update to the Deep Station rayleigh reader
+to make it more robust against the presence of blank lines.

--- a/log.txt
+++ b/log.txt
@@ -1702,3 +1702,18 @@ In Interaction::PickNear_Sphere, which is setting vertex positions, the 'adding 
 So, if we use DETECTOR=4, It will do nothing
 I added 'detector->Get_mode() == 4' option in the Interaction::PickNear_Sphere. 
 So that user can use effective area (INTERACTION_MODE=0) mode with deployed station mode (DETECTOR=4)
+
+==============================================================================
+2023/02/28 Brian Clark
+
+Changes were made to the Detector and Settings classes to enable
+AraSim to simulate A4 and A5, the fourth and fifth ARA stations.
+
+In Settings, this required altering CheckCompatibilitiesSettings
+to allow for detector livetime configs to work for stations larger than A2 an A3.
+
+In Detector.cc, the really important change was updating the function
+SetupInstalledStations to have the A4 and A5 geometry information.
+I also linted the main Detector function to fix a bunch of tabbing issues.
+This improved readability.
+


### PR DESCRIPTION
This add support to AraSim for stations A4 and A5.

In Settings, this required altering `CheckCompatibilitiesSettings` to allow for detector livetime configs to work for stations larger than A2 an A3.

In Detector.cc, the really important change was updating the function `SetupInstalledStations` to have the A4 and A5 geometry information.

I also linted the main Detector function to fix a bunch of tabbing issues. This improved readability, but results in a large diff. But I think it's worth it.

There's also a minor update to the Deep Station rayleigh reader (`ReadRayleighFit_DeepStation`) to make it more robust against the presence of blank lines.
