### PR TITLE
Define global source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 eventSimDict.C
 eventSimDict.h
 AraSim
-*.ipynb
+*.ipynb*
+jobfiles/
+outputs/

--- a/Primaries.cc
+++ b/Primaries.cc
@@ -971,7 +971,33 @@ Interaction::Interaction(IceModel *antarctica, Detector *detector, Settings *set
       PickNear_Cylinder_AboveIce (antarctica, detector, settings1);
       
     }
-
+    //Adding interaction mode where user can define source at lattitude, longitude, and altitude.  Useful for pulser simulations or coincidence analysis. - JCF 3/28/2023
+    else if (settings1->INTERACTION_MODE == 5) {
+        //Import latitude and longitude of source. Defaults to SpiceCore 2023 lat/long of (-89.97953, -100.78595) at depth of 1000 meters.
+        double sourceLatitude = settings1->SOURCE_LATITUDE;
+        double sourceLongitude = settings1->SOURCE_LONGITUDE;
+        double sourceDepth = settings1->SOURCE_DEPTH;
+        Int_t stationId = settings1->DETECTOR_STATION;
+        //Calculate array coordinates of source
+        double sourceEasting = AraGeomTool::getArrayEastingFromLatLong(sourceLatitude, sourceLongitude);
+        double sourceNorthing = AraGeomTool::getArrayNorthingFromLatLong(sourceLatitude, sourceLongitude);
+        //Construct vector of source in array coordinates
+        TVector3 sourceArrayVector;
+        sourceArrayVector[0] = sourceEasting;
+        sourceArrayVector[1] = sourceNorthing;
+        sourceArrayVector[2] = sourceDepth;
+        //Convert source vector into array coordinates
+        TVector3 sourceStationVector = AraGeomTool::Instance()->convertArrayToStationCoords(stationId, sourceArrayVector);
+        //Calculate posnu
+        double R = sqrt(pow(sourceStationVector[0],2) + pow(sourceStationVector[1],2) + pow(sourceStationVector[2],2));
+        double phi = (360+(atan2(sourceStationVector[1], sourceStationVector[0]))*180/PI)*PI/180;
+        double theta = acos((sourceStationVector[2])/R);
+        settings1->POSNU_THETA = theta;
+        settings1->POSNU_PHI = phi;
+        settings1->POSNU_R = R;
+        //Set source location using posnu.
+        PickExact(antarctica, detector, settings1, settings1->POSNU_R, settings1->POSNU_THETA, settings1->POSNU_PHI);
+    }
     
     
   }
@@ -1126,7 +1152,33 @@ Interaction::Interaction (double pnu, string nuflavor, int nu_nubar, int &n_inte
       
     }
 
-
+    //Adding interaction mode where user can define source at lattitude, longitude, and altitude.  Useful for pulser simulations or coincidence analysis. - JCF 3/28/2023
+    else if (settings1->INTERACTION_MODE == 5) {
+        //Import latitude and longitude of source. Defaults to SpiceCore 2023 lat/long of (-89.97953, -100.78595) at depth of 1000 meters.
+        double sourceLatitude = settings1->SOURCE_LATITUDE;
+        double sourceLongitude = settings1->SOURCE_LONGITUDE;
+        double sourceDepth = settings1->SOURCE_DEPTH;
+        Int_t stationId = settings1->DETECTOR_STATION;
+        //Calculate array coordinates of source
+        double sourceEasting = AraGeomTool::getArrayEastingFromLatLong(sourceLatitude, sourceLongitude);
+        double sourceNorthing = AraGeomTool::getArrayNorthingFromLatLong(sourceLatitude, sourceLongitude);
+        //Construct vector of source in array coordinates
+        TVector3 sourceArrayVector;
+        sourceArrayVector[0] = sourceEasting;
+        sourceArrayVector[1] = sourceNorthing;
+        sourceArrayVector[2] = sourceDepth;
+        //Convert source vector into array coordinates
+        TVector3 sourceStationVector = AraGeomTool::Instance()->convertArrayToStationCoords(stationId, sourceArrayVector);
+        //Calculate posnu
+        double R = sqrt(pow(sourceStationVector[0],2) + pow(sourceStationVector[1],2) + pow(sourceStationVector[2],2));
+        double phi = (360+(atan2(sourceStationVector[1], sourceStationVector[0]))*180/PI)*PI/180;
+        double theta = acos((sourceStationVector[2])/R);
+        settings1->POSNU_THETA = theta;
+        settings1->POSNU_PHI = phi;
+        settings1->POSNU_R = R;
+        //Set source location using posnu.
+        PickExact(antarctica, detector, settings1, settings1->POSNU_R, settings1->POSNU_THETA, settings1->POSNU_PHI);
+    }
 
     }
     //cout<<" Finished Pick posnu, r_in, r_enterice, nuexitice!!"<<endl;
@@ -1513,7 +1565,33 @@ Interaction::Interaction (Settings *settings1, Detector *detector, IceModel *ant
 	}
     }
 	
-	
+    //Adding interaction mode where user can define source at lattitude, longitude, and altitude.  Useful for pulser simulations or coincidence analysis. - JCF 3/28/2023
+    else if (settings1->INTERACTION_MODE == 5) {
+        //Import latitude and longitude of source. Defaults to SpiceCore 2023 lat/long of (-89.97953, -100.78595) at depth of 1000 meters.
+        double sourceLatitude = settings1->SOURCE_LATITUDE;
+        double sourceLongitude = settings1->SOURCE_LONGITUDE;
+        double sourceDepth = settings1->SOURCE_DEPTH;
+        Int_t stationId = settings1->DETECTOR_STATION;
+        //Calculate array coordinates of source
+        double sourceEasting = AraGeomTool::getArrayEastingFromLatLong(sourceLatitude, sourceLongitude);
+        double sourceNorthing = AraGeomTool::getArrayNorthingFromLatLong(sourceLatitude, sourceLongitude);
+        //Construct vector of source in array coordinates
+        TVector3 sourceArrayVector;
+        sourceArrayVector[0] = sourceEasting;
+        sourceArrayVector[1] = sourceNorthing;
+        sourceArrayVector[2] = sourceDepth;
+        //Convert source vector into array coordinates
+        TVector3 sourceStationVector = AraGeomTool::Instance()->convertArrayToStationCoords(stationId, sourceArrayVector);
+        //Calculate posnu
+        double R = sqrt(pow(sourceStationVector[0],2) + pow(sourceStationVector[1],2) + pow(sourceStationVector[2],2));
+        double phi = (360+(atan2(sourceStationVector[1], sourceStationVector[0]))*180/PI)*PI/180;
+        double theta = acos((sourceStationVector[2])/R);
+        settings1->POSNU_THETA = theta;
+        settings1->POSNU_PHI = phi;
+        settings1->POSNU_R = R;
+        //Set source location using posnu.
+        PickExact(antarctica, detector, settings1, settings1->POSNU_R, settings1->POSNU_THETA, settings1->POSNU_PHI);
+    }	
 
     
     double tmp; // for useless information

--- a/Primaries.cc
+++ b/Primaries.cc
@@ -972,33 +972,13 @@ Interaction::Interaction(IceModel *antarctica, Detector *detector, Settings *set
       PickNear_Cylinder_AboveIce (antarctica, detector, settings1);
       
     }
+    #ifdef ARA_UTIL_EXISTS
     //Adding interaction mode where user can define source at lattitude, longitude, and altitude.  Useful for pulser simulations or coincidence analysis. - JCF 3/28/2023
     else if (settings1->INTERACTION_MODE == 5) {
-        //Import latitude and longitude of source. Defaults to SpiceCore 2023 lat/long of (-89.97953, -100.78595) at depth of 1000 meters.
-        double sourceLatitude = settings1->SOURCE_LATITUDE;
-        double sourceLongitude = settings1->SOURCE_LONGITUDE;
-        double sourceDepth = settings1->SOURCE_DEPTH;
-        Int_t stationId = settings1->DETECTOR_STATION;
-        //Calculate array coordinates of source
-        double sourceEasting = AraGeomTool::getArrayEastingFromLatLong(sourceLatitude, sourceLongitude);
-        double sourceNorthing = AraGeomTool::getArrayNorthingFromLatLong(sourceLatitude, sourceLongitude);
-        //Construct vector of source in array coordinates
-        TVector3 sourceArrayVector;
-        sourceArrayVector[0] = sourceEasting;
-        sourceArrayVector[1] = sourceNorthing;
-        sourceArrayVector[2] = sourceDepth;
-        //Convert source vector into array coordinates
-        TVector3 sourceStationVector = AraGeomTool::Instance()->convertArrayToStationCoords(stationId, sourceArrayVector);
-        //Calculate posnu
-        double R = sqrt(pow(sourceStationVector[0],2) + pow(sourceStationVector[1],2) + pow(sourceStationVector[2],2));
-        double phi = (360+(atan2(sourceStationVector[1], sourceStationVector[0]))*180/PI)*PI/180;
-        double theta = acos((sourceStationVector[2])/R);
-        settings1->POSNU_THETA = theta;
-        settings1->POSNU_PHI = phi;
-        settings1->POSNU_R = R;
-        //Set source location using posnu.
-        PickExact(antarctica, detector, settings1, settings1->POSNU_R, settings1->POSNU_THETA, settings1->POSNU_PHI);
+        //Defaults to SpiceCore 2023 lat/long of (-89.97953, -100.78595) at depth of 1000 meters.
+        PickExactGlobal(antarctica, detector, settings1, settings1->SOURCE_LATITUDE, settings1->SOURCE_LONGITUDE, settings1->SOURCE_DEPTH);
     }
+    #endif
     
     
   }
@@ -1152,34 +1132,13 @@ Interaction::Interaction (double pnu, string nuflavor, int nu_nubar, int &n_inte
       PickNear_Cylinder_AboveIce (antarctica, detector, settings1);
       
     }
-
+    #ifdef ARA_UTIL_EXISTS
     //Adding interaction mode where user can define source at lattitude, longitude, and altitude.  Useful for pulser simulations or coincidence analysis. - JCF 3/28/2023
     else if (settings1->INTERACTION_MODE == 5) {
-        //Import latitude and longitude of source. Defaults to SpiceCore 2023 lat/long of (-89.97953, -100.78595) at depth of 1000 meters.
-        double sourceLatitude = settings1->SOURCE_LATITUDE;
-        double sourceLongitude = settings1->SOURCE_LONGITUDE;
-        double sourceDepth = settings1->SOURCE_DEPTH;
-        Int_t stationId = settings1->DETECTOR_STATION;
-        //Calculate array coordinates of source
-        double sourceEasting = AraGeomTool::getArrayEastingFromLatLong(sourceLatitude, sourceLongitude);
-        double sourceNorthing = AraGeomTool::getArrayNorthingFromLatLong(sourceLatitude, sourceLongitude);
-        //Construct vector of source in array coordinates
-        TVector3 sourceArrayVector;
-        sourceArrayVector[0] = sourceEasting;
-        sourceArrayVector[1] = sourceNorthing;
-        sourceArrayVector[2] = sourceDepth;
-        //Convert source vector into array coordinates
-        TVector3 sourceStationVector = AraGeomTool::Instance()->convertArrayToStationCoords(stationId, sourceArrayVector);
-        //Calculate posnu
-        double R = sqrt(pow(sourceStationVector[0],2) + pow(sourceStationVector[1],2) + pow(sourceStationVector[2],2));
-        double phi = (360+(atan2(sourceStationVector[1], sourceStationVector[0]))*180/PI)*PI/180;
-        double theta = acos((sourceStationVector[2])/R);
-        settings1->POSNU_THETA = theta;
-        settings1->POSNU_PHI = phi;
-        settings1->POSNU_R = R;
-        //Set source location using posnu.
-        PickExact(antarctica, detector, settings1, settings1->POSNU_R, settings1->POSNU_THETA, settings1->POSNU_PHI);
+        //Defaults to SpiceCore 2023 lat/long of (-89.97953, -100.78595) at depth of 1000 meters.
+        PickExactGlobal(antarctica, detector, settings1, settings1->SOURCE_LATITUDE, settings1->SOURCE_LONGITUDE, settings1->SOURCE_DEPTH);
     }
+    #endif
 
     }
     //cout<<" Finished Pick posnu, r_in, r_enterice, nuexitice!!"<<endl;
@@ -1564,36 +1523,15 @@ Interaction::Interaction (Settings *settings1, Detector *detector, IceModel *ant
 	  //Interaction::PickNear (antarctica, detector, settings1);
 	  PickNear_Cylinder_AboveIce (antarctica, detector, settings1);
 	}
-    }
-	
+
+	#ifdef ARA_UTIL_EXISTS
     //Adding interaction mode where user can define source at lattitude, longitude, and altitude.  Useful for pulser simulations or coincidence analysis. - JCF 3/28/2023
     else if (settings1->INTERACTION_MODE == 5) {
-        //Import latitude and longitude of source. Defaults to SpiceCore 2023 lat/long of (-89.97953, -100.78595) at depth of 1000 meters.
-        double sourceLatitude = settings1->SOURCE_LATITUDE;
-        double sourceLongitude = settings1->SOURCE_LONGITUDE;
-        double sourceDepth = settings1->SOURCE_DEPTH;
-        Int_t stationId = settings1->DETECTOR_STATION;
-        //Calculate array coordinates of source
-        double sourceEasting = AraGeomTool::getArrayEastingFromLatLong(sourceLatitude, sourceLongitude);
-        double sourceNorthing = AraGeomTool::getArrayNorthingFromLatLong(sourceLatitude, sourceLongitude);
-        //Construct vector of source in array coordinates
-        TVector3 sourceArrayVector;
-        sourceArrayVector[0] = sourceEasting;
-        sourceArrayVector[1] = sourceNorthing;
-        sourceArrayVector[2] = sourceDepth;
-        //Convert source vector into array coordinates
-        TVector3 sourceStationVector = AraGeomTool::Instance()->convertArrayToStationCoords(stationId, sourceArrayVector);
-        //Calculate posnu
-        double R = sqrt(pow(sourceStationVector[0],2) + pow(sourceStationVector[1],2) + pow(sourceStationVector[2],2));
-        double phi = (360+(atan2(sourceStationVector[1], sourceStationVector[0]))*180/PI)*PI/180;
-        double theta = acos((sourceStationVector[2])/R);
-        settings1->POSNU_THETA = theta;
-        settings1->POSNU_PHI = phi;
-        settings1->POSNU_R = R;
-        //Set source location using posnu.
-        PickExact(antarctica, detector, settings1, settings1->POSNU_R, settings1->POSNU_THETA, settings1->POSNU_PHI);
-    }	
-
+        //Defaults to SpiceCore 2023 lat/long of (-89.97953, -100.78595) at depth of 1000 meters.
+        PickExactGlobal(antarctica, detector, settings1, settings1->SOURCE_LATITUDE, settings1->SOURCE_LONGITUDE, settings1->SOURCE_DEPTH);
+    }
+    #endif
+    }
     
     double tmp; // for useless information
     
@@ -3313,6 +3251,34 @@ void Interaction::PickAnyDirection() {
 
 
 }
+#ifdef ARA_UTIL_EXISTS
+void Interaction::PickExactGlobal(IceModel *antarctica, Detector *detector, Settings *settings1, double thisLat, double thisLong, double thisDepth) {
+        double sourceLatitude = thisLat;
+        double sourceLongitude = thisLong;
+        double sourceDepth = thisDepth;
+        Int_t stationId = settings1->DETECTOR_STATION;
+        //Calculate array coordinates of source
+        double sourceEasting = AraGeomTool::getArrayEastingFromLatLong(sourceLatitude, sourceLongitude);
+        double sourceNorthing = AraGeomTool::getArrayNorthingFromLatLong(sourceLatitude, sourceLongitude);
+        //Construct vector of source in array coordinates
+        TVector3 sourceArrayVector;
+        sourceArrayVector[0] = sourceEasting;
+        sourceArrayVector[1] = sourceNorthing;
+        sourceArrayVector[2] = sourceDepth;
+        //Convert source vector into array coordinates
+        TVector3 sourceStationVector = AraGeomTool::Instance()->convertArrayToStationCoords(stationId, sourceArrayVector);
+        //Calculate posnu
+        double R = sqrt(pow(sourceStationVector[0],2) + pow(sourceStationVector[1],2) + pow(sourceStationVector[2],2));
+        double phi = (360+(atan2(sourceStationVector[1], sourceStationVector[0]))*180/PI)*PI/180;
+        double theta = acos((sourceStationVector[2])/R);
+        settings1->POSNU_THETA = theta;
+        settings1->POSNU_PHI = phi;
+        settings1->POSNU_R = R;
+        //Set source location using posnu.
+        PickExact(antarctica, detector, settings1, settings1->POSNU_R, settings1->POSNU_THETA, settings1->POSNU_PHI);
+
+}
+#endif
 
 // removed this function as it's set in Event class
 //

--- a/Primaries.cc
+++ b/Primaries.cc
@@ -19,7 +19,7 @@
 #include "signal.hh"
 #include "RaySolver.h"
 #include "Report.h"
-#include "AraGeomTool.h"
+
 
 //#include "vector.hh"
 //#include "position.hh"

--- a/Primaries.cc
+++ b/Primaries.cc
@@ -19,6 +19,7 @@
 #include "signal.hh"
 #include "RaySolver.h"
 #include "Report.h"
+#include "AraGeomTool.h"
 
 //#include "vector.hh"
 //#include "position.hh"

--- a/Primaries.h
+++ b/Primaries.h
@@ -311,6 +311,7 @@ Interaction (IceModel *antarctica, Detector *detector, Settings *settings1, Prim
     // end move from IceModel
   //
 
+    void PickExactGlobal(IceModel *antarctica, Detector *detector, Settings *settings1, double thisLat, double thisLong, double thisDepth);
 
   double pathlength_inice;
 

--- a/Settings.cc
+++ b/Settings.cc
@@ -696,13 +696,13 @@ void Settings::ReadFile(string setupfile) {
               }
           //Adding source easting, northing, and depth for INTERACTION_MODE=5.
           else if (label == "SOURCE_LATITUDE"){
-              SOURCE_LATITUDE = atoi(line.substr(line.find_first_of("=") + 1).c_str());
+              SOURCE_LATITUDE = atof(line.substr(line.find_first_of("=") + 1).c_str());
           }
           else if (label == "SOURCE_LONGITUDE"){
-              SOURCE_LONGITUDE = atoi(line.substr(line.find_first_of("=") + 1).c_str());
+              SOURCE_LONGITUDE = atof(line.substr(line.find_first_of("=") + 1).c_str());
           }
           else if (label == "SOURCE_DEPTH"){
-               SOURCE_DEPTH = atoi(line.substr(line.find_first_of("=") + 1).c_str());
+               SOURCE_DEPTH = atof(line.substr(line.find_first_of("=") + 1).c_str());
           }
 
 

--- a/Settings.cc
+++ b/Settings.cc
@@ -694,7 +694,16 @@ void Settings::ReadFile(string setupfile) {
               else if (label == "CUSTOM_ELECTRONICS"){
               	   CUSTOM_ELECTRONICS = atoi(line.substr(line.find_first_of("=") + 1).c_str());
               }
-
+          //Adding source easting, northing, and depth for INTERACTION_MODE=5.
+          else if (label == "SOURCE_LATITUDE"){
+              SOURCE_LATITUDE = atoi(line.substr(line.find_first_of("=") + 1).c_str());
+          }
+          else if (label == "SOURCE_LONGITUDE"){
+              SOURCE_LONGITUDE = atoi(line.substr(line.find_first_of("=") + 1).c_str());
+          }
+          else if (label == "SOURCE_DEPTH"){
+               SOURCE_DEPTH = atoi(line.substr(line.find_first_of("=") + 1).c_str());
+          }
 
 
 

--- a/Settings.cc
+++ b/Settings.cc
@@ -230,6 +230,13 @@ outputdir="outputs"; // directory where outputs go
 
     ONLY_PASSED_EVENTS = 0;
     NNU_PASSED = 0;
+    
+    //Defining source for INTERACTION_MODE == 5.
+    SOURCE_LATITUDE = -89.97953; //Latitude of SpiceCore (from 2023 survey data)
+
+    SOURCE_LONGITUDE = -100.78595; //Longitude of SpiceCore (from 2023 survey data)
+
+    SOURCE_DEPTH = -1000.0; //Default depth of 1000 meters below ice surface.
 
 
 

--- a/Settings.h
+++ b/Settings.h
@@ -179,6 +179,11 @@ class Settings
     
         double CONST_RMSDIODE;  // in case NOISE_CHANNEL_MODE = 1, just using this CONST_RMSDIODE value for threshold
 
+        double SOURCE_LATITUDE;  //Latitude, Longitude, and depth of simulating source in global coordinates for use in INTERACTION_MODE=5.
+
+        double SOURCE_LONGITUDE;
+
+        double SOURCE_DEPTH;
 
         int USE_TESTBED_RFCM_ON;    // use RFCM measurement for testbed or not (default 0)
     


### PR DESCRIPTION
Added INTERACTION_MODE==5, where the user can define a latitude and longitude and simulate a source at that position.   This converts the latitude and longitude to the coordinates of whichever station you're simulating, which relies on AraGeomTool in AraRoot.  This can be done in your setup file by specifying:

- INTERACTION_MODE=5
- SOURCE_LATITUDE (Default = -89.98953)
- SOURCE_LONGITUDE (Default = -100.78595)
- SOURCE_DEPTH  (Default = -1000)

The default latitude and longitude correspond to the 2023 surveyed position of SpiceCore.