### PR TITLE
Tiny update for ray tracing

### DIFF
--- a/RaySolver.cc
+++ b/RaySolver.cc
@@ -1117,6 +1117,11 @@ void RaySolver::Solve_Ray (Position &source, Position &target, IceModel *antarct
       ns = 1.357;
       nd = 1.78;
       nc = 0.027;
+    } else if (settings1->RAY_TRACE_ICE_MODEL_PARAMS == 40){ //! MK added -2023-05-02-
+      // UNL Modified (PA model). Related slide: https://aradocs.wipac.wisc.edu/docs/0022/002222/001/inIceMC_Hughes_A5locations_10222020.pdf
+      ns = 1.326;
+      nd = 1.78;
+      nc = 0.0202;
     }
     else {
       // South Pole Values (AraSim original default, based on RICE)

--- a/Settings.cc
+++ b/Settings.cc
@@ -169,7 +169,7 @@ outputdir="outputs"; // directory where outputs go
 
   NNU_D_PHI=0.0873;// default : nnu_d_phi : 5 deg
 
-  Z_THIS_TOLERANCE=0; // 0 : (default) use default 'requiredAccuracy' parameter for ray tracing, 1 : change 'requiredAccuracy' parameter by Z_TOLERANCE
+  Z_THIS_TOLERANCE=1; // 0 : use default 'requiredAccuracy' metod for ray tracing, 1 (default) : change 'requiredAccuracy' parameter by Z_TOLERANCE
 
   Z_TOLERANCE=0.2; // 0.2 : (default)   
  

--- a/log.txt
+++ b/log.txt
@@ -1775,4 +1775,17 @@ there functions here:
 
 Full documentation of this work is available on DocDB: https://aradocs.wipac.wisc.edu/cgi-bin/DocDB/ShowDocument?docid=2757 
  
- ==============================================================================
+==============================================================================
+
+2023/05/02 Myoungchul Kim
+
+Default value of Z_THIS_TOLERANCE is now 1
+Unless user changes Z_THIS_TOLERANCE to 0 which is dynamic requiredAccuracy setting, 
+requiredAccuracy is always follow Z_TOLERANCE parameter which is 0.2 as a default
+
+Added PA ice model in RaySolver.cc
+If user set RAY_TRACE_ICE_MODEL_PARAMS = 40, AraSim will use UNL Modified (PA model).
+Related slide: https://aradocs.wipac.wisc.edu/docs/0022/002222/001/inIceMC_Hughes_A5locations_10222020.pdf
+
+==============================================================================
+


### PR DESCRIPTION
The default value of `Z_THIS_TOLERANCE` is now 1
Unless the user changes `Z_THIS_TOLERANCE` to 0, which is a dynamic `requiredAccuracy` setting,
`requiredAccuracy` always follows the `Z_TOLERANCE` parameter, which is 0.2 as a default

Added PA ice model in RaySolver.cc
If the user sets `RAY_TRACE_ICE_MODEL_PARAMS=40`, AraSim will use UNL Modified (PA model).
Related [slide](https://aradocs.wipac.wisc.edu/docs/0022/002222/001/inIceMC_Hughes_A5locations_10222020.pdf)