### PR TITLE
Re-calculate Nu position from antenna center

### DIFF
--- a/Primaries.cc
+++ b/Primaries.cc
@@ -975,6 +975,10 @@ Interaction::Interaction(IceModel *antarctica, Detector *detector, Settings *set
     
     
   }
+
+  //! re-calculate Nu position (x, y, z, r, theta, phi) from antenna center point of view. MK added -2023-05-19-
+  PosNuFromAntennaCenter(detector);
+
   //cout<<" Finished Pick posnu, r_in, r_enterice, nuexitice!!"<<endl;
   
   
@@ -1129,6 +1133,10 @@ Interaction::Interaction (double pnu, string nuflavor, int nu_nubar, int &n_inte
 
 
     }
+
+    //! re-calculate Nu position (x, y, z, r, theta, phi) from antenna center point of view. MK added -2023-05-19-
+    PosNuFromAntennaCenter(detector);
+
     //cout<<" Finished Pick posnu, r_in, r_enterice, nuexitice!!"<<endl;
 
 
@@ -1513,8 +1521,8 @@ Interaction::Interaction (Settings *settings1, Detector *detector, IceModel *ant
 	}
     }
 	
-	
-
+	//! re-calculate Nu position (x, y, z, r, theta, phi) from antenna center point of view. MK added -2023-05-19-
+    PosNuFromAntennaCenter(detector);
     
     double tmp; // for useless information
     
@@ -2393,7 +2401,6 @@ void Interaction::PickExact (IceModel *antarctica, Detector *detector, Settings 
     double avgY = sumY/double(count);
     double avgZ = sumZ/double(count);
     
-    
 //    std::cout << "DetectorStation:X:Y:: "  << detector->stations[0].GetX() << " : " << detector->stations[0].GetY() << std::endl;
     printf("avgx: %.5f, avgy: %.5f, avgz: %.5f, detectorx: %.5f, detectory: %.5f, detectorz: %.5f, icesurface: %.5f\n", avgX, avgY, avgZ, detector->stations[0].GetX(), detector->stations[0].GetY(), detector->stations[0].GetZ(), antarctica->Surface(detector->stations[0].Lon(), detector->stations[0].Lat()));
     
@@ -2406,6 +2413,7 @@ void Interaction::PickExact (IceModel *antarctica, Detector *detector, Settings 
         Y = avgY + thisR*sin(thisPhi)*sin(thisTheta);
         D = pow(X*X + Y*Y, 0.5);
         //interaction1->posnu.SetThetaPhi( D/antarctica->Surface(0., 0.), atan2(Y,X) ); 
+        
     }
     //calculate posnu's X, Y wrt to (0,0)
     else {  // for mode = 0 (testbed)
@@ -3209,7 +3217,44 @@ void Interaction::FlattoEarth_Spherical ( IceModel *antarctica, double X, double
   posnu.SetR( antarctica->Surface(posnu.Lon(), posnu.Lat()) + (Z) ); // note Z is negative
 }
 
+/*!
+    MK added -2023-05-19-
+    re-calculate Neutrino position from antenna center point of view 
+    Neutrino x,y,z,r,theta,phi will be saved on Position posnu_from_antcen array
+     
+*/
 
+void Interaction::PosNuFromAntennaCenter (Detector *detector) {
+
+    //! calculate antenna center
+    double avgX = 0.;
+    double avgY = 0.;
+    double avgZ = 0.;
+    int count = 0;
+
+    //! load antenna XYZ position
+    for (int i = 0; i < detector->stations[0].strings.size(); i++){
+        for (int j = 0; j < detector->stations[0].strings[i].antennas.size(); j++){
+            avgX = avgX + detector->stations[0].strings[i].antennas[j].GetX();
+            avgY = avgY + detector->stations[0].strings[i].antennas[j].GetY();
+            avgZ = avgZ + detector->stations[0].strings[i].antennas[j].GetZ();
+            count++;
+        }
+    }
+
+    avgX /= double(count);
+    avgY /= double(count);
+    avgZ /= double(count);
+
+    //! calculate Neutrino XYZ position from antenna center point of view
+    double posnu_x = posnu.GetX() - avgX;
+    double posnu_y = posnu.GetY() - avgY;
+    double posnu_z = posnu.GetZ() - avgZ;
+
+    //! store in array
+    posnu_from_antcen.SetXYZ(posnu_x, posnu_y, posnu_z); ///< SetXYZ() in Vector class will automatically update r, thrta, and phi by UpdateThetaPhi()
+
+}
      
 void Interaction::PickAnyDirection() {
   double rndlist[2];

--- a/Primaries.h
+++ b/Primaries.h
@@ -296,6 +296,8 @@ Interaction (IceModel *antarctica, Detector *detector, Settings *settings1, Prim
   void FlattoEarth_Near_Surface ( IceModel *antarctica, double X, double Y, double D, double max_depth);
   void FlattoEarth_Spherical ( IceModel *antarctica, double X, double Y, double Z);
 
+  void PosNuFromAntennaCenter (Detector *detector); ///< re-calculate Neutrino position (x, y, z, r, theta, phi) from antenna center point of view. MK added -2023-05-19-
+
   void PickNear_Cylinder (IceModel *antarctica, Detector *detector, Settings *settings1);
   double PickNear_Sphere (IceModel *antarctica, Detector *detector, Settings *settings1);
 
@@ -373,6 +375,7 @@ static const double banana_signal_fluct;//Turn off noise for banana plots (setti
 // void setCurrent(Primaries *primary1);
   void setCurrent(Primaries *primary1, Settings *settings1);
   Position posnu;
+  Position posnu_from_antcen; ///< Nu position (x,y,z,r,theta,phi) from antenna center. MK added -2023-05-19-
   Position posnu_down;
 //--------------------------------------------------
 // string  nuflavor;                   // neutrino flavor
@@ -431,7 +434,7 @@ double dnutries; //product of dtryingdirection and dtryingposition
 
  */
 
- ClassDef(Interaction,1);
+ ClassDef(Interaction,2);
 
 
 };//Interaction

--- a/log.txt
+++ b/log.txt
@@ -1812,3 +1812,15 @@ I just decided to implement it inside the sim...
 
 ==============================================================================
 
+2023/05/19 Myoungchul Kim
+
+We are only saving the Nu position (x, y, z, r, theta, phi) from the earth's center point of view.
+So, the true theta and phi values of Neutrino are not much useful for the current reconstruction method.
+And in order to compare the reconstructed Nu position with the true Nu position, we (at least me) need to recalculate the true position from the antenna center point of view.
+I decided to add another Nu position that calculated from the antenna center
+
+PosNuFromAntennaCenter() in the Primaries class will load antenna and Nu positions, and apply simply built-in SetXYZ() in Vector class
+The re-calculated value will be saved in the posnu_from_antcen array
+
+==============================================================================
+


### PR DESCRIPTION
We are only saving the Nu position (x, y, z, r, theta, phi) from the earth's center point of view. 
So, the true theta and phi values of Neutrino are not much useful for the current reconstruction method.
And in order to compare the reconstructed Nu position with the true Nu position, we (at least me) need to recalculate the true position from the antenna center point of view.
I decided to add another Nu position that calculated from the antenna center

`PosNuFromAntennaCenter()` in the `Primaries` class will load antenna and Nu positions, and apply simply built-in `SetXYZ()` in `Vector` class
The re-calculated value will be saved in the `posnu_from_antcen` array

Let me know if this calculation is already in AraSim!