### PR TITLE
Dynamic NFOUR option and clean up several classes

### DIFF
--- a/AraSim.cc
+++ b/AraSim.cc
@@ -287,11 +287,6 @@ int main(int argc, char **argv) {   // read setup.txt file
 
     */
 
-    double x_V[settings1->NFOUR/2];
-    double y_V[settings1->NFOUR/2];
-
-
-
     double xbin[settings1->DATA_BIN_SIZE];
     for (int i=0; i<settings1->DATA_BIN_SIZE; i++) {
         xbin[i] = i;

--- a/Detector.cc
+++ b/Detector.cc
@@ -3355,23 +3355,6 @@ inline void Detector::ReadFilter(string filename, Settings *settings1) {    // w
         FilterGain_databin.push_back( ygain_databin[i] );
     }
     
-    
-    // for NFOUR/2 t domain array
-    double xfreq_NFOUR[settings1->NFOUR/4+1];   // array for FFT freq bin
-    double ygain_NFOUR[settings1->NFOUR/4+1];   // array for gain in FFT bin
-    
-    df_fft = 1./ ( (double)(settings1->NFOUR/2) * settings1->TIMESTEP );
-
-    for (int i=0;i<settings1->NFOUR/4+1;i++) {    // this one is for DATA_BIN_SIZE
-        xfreq_NFOUR[i] = (double)i * df_fft / (1.E6); // from Hz to MHz
-    }
-
-    Tools::SimpleLinearInterpolation( N, xfreq, ygain, settings1->NFOUR/4+1, xfreq_NFOUR, ygain_NFOUR );
-    
-    for (int i=0;i<settings1->NFOUR/4+1;i++) {
-        FilterGain_NFOUR.push_back( ygain_NFOUR[i] );
-    }
-    
 }
 
 
@@ -3459,24 +3442,6 @@ inline void Detector::ReadPreamp(string filename, Settings *settings1) {    // w
     for (int i=0;i<settings1->DATA_BIN_SIZE/2;i++) {
         PreampGain_databin.push_back( ygain_databin[i] );
     }
-    
-    
-    // for NFOUR/2 t domain array
-    double xfreq_NFOUR[settings1->NFOUR/4+1];   // array for FFT freq bin
-    double ygain_NFOUR[settings1->NFOUR/4+1];   // array for gain in FFT bin
-    
-    df_fft = 1./ ( (double)(settings1->NFOUR/2) * settings1->TIMESTEP );
-
-    for (int i=0;i<settings1->NFOUR/4+1;i++) {    // this one is for DATA_BIN_SIZE
-        xfreq_NFOUR[i] = (double)i * df_fft / (1.E6); // from Hz to MHz
-    }
-
-    Tools::SimpleLinearInterpolation( N, xfreq, ygain, settings1->NFOUR/4+1, xfreq_NFOUR, ygain_NFOUR );
-    
-    for (int i=0;i<settings1->NFOUR/4+1;i++) {
-        PreampGain_NFOUR.push_back( ygain_NFOUR[i] );
-    }
-    
     
 }
 
@@ -3568,22 +3533,6 @@ inline void Detector::ReadFOAM(string filename, Settings *settings1) {    // wil
         FOAMGain_databin.push_back( ygain_databin[i] );
     }
     
-
-    // for NFOUR/2 t domain array
-    double xfreq_NFOUR[settings1->NFOUR/4+1];   // array for FFT freq bin
-    double ygain_NFOUR[settings1->NFOUR/4+1];   // array for gain in FFT bin
-    
-    df_fft = 1./ ( (double)(settings1->NFOUR/2) * settings1->TIMESTEP );
-
-    for (int i=0;i<settings1->NFOUR/4+1;i++) {    // this one is for DATA_BIN_SIZE
-        xfreq_NFOUR[i] = (double)i * df_fft / (1.E6); // from Hz to MHz
-    }
-
-    Tools::SimpleLinearInterpolation( N, xfreq, ygain, settings1->NFOUR/4+1, xfreq_NFOUR, ygain_NFOUR );
-    
-    for (int i=0;i<settings1->NFOUR/4+1;i++) {
-        FOAMGain_NFOUR.push_back( ygain_NFOUR[i] );
-    }
 }
 
 void Detector::ReadNoiseFigure(string filename, Settings *settings1)

--- a/Detector.cc
+++ b/Detector.cc
@@ -4960,7 +4960,6 @@ void Detector::getDiodeModel(Settings *settings1) {
     // now get f domain response with realft
     
     double diode_real_fft[settings1->DATA_BIN_SIZE*2];  // double sized array for myconvlv
-    //double diode_real_fft[settings1->DATA_BIN_SIZE + 512];  // DATA_BIN_SIZE + 512 bin (zero padding) for myconvlv
     double diode_real_fft_half[NFOUR];    // double sized array for NFOUR/2
     double diode_real_fft_double[NFOUR*2];    // test with NFOUR*2 array
     

--- a/Detector.cc
+++ b/Detector.cc
@@ -5065,7 +5065,6 @@ void Detector::get_NewDiodeModel(Settings *settings1) {
     fdiode_real_databin.clear();
 
     // save f domain diode response in fdiode_real
-    //for (int i=0; i<settings1->DATA_BIN_SIZE+512; i++) {
     for (int i=0; i<settings1->DATA_BIN_SIZE*2; i++) {
         fdiode_real_databin.push_back( diode_real_fft[i] );
     }

--- a/Detector.cc
+++ b/Detector.cc
@@ -5071,12 +5071,12 @@ void Detector::get_NewDiodeModel(Settings *settings1) {
 
 }
 
-//! repadding diode value based on input pad length
+//! repadding diode value based on input pad length. MK added -2023-05-23-
 void Detector::get_NewDynamicDiodeModel(int pad_len) {
 
     double diode_real_fft[pad_len * 2]; ///< double sized array for myconvlv
 
-    for (int i = 0; i < pad_len * 2; i++) {  // 512 bin added for zero padding
+    for (int i = 0; i < pad_len * 2; i++) {  ///< add diode value in zero pad
         if ( i < (int)(maxt_diode / TIMESTEP) ) {
             diode_real_fft[i] = diode_real[i];
         } else {
@@ -5084,13 +5084,13 @@ void Detector::get_NewDynamicDiodeModel(int pad_len) {
         }
     }
 
-    // forward FFT
+    //! forward FFT
     Tools::realft(diode_real_fft, 1, pad_len * 2);
 
-    // clear previous data as we need new diode response array for new pad_len
+    //! clear previous data as we need new diode response array for new pad_len
     fdiode_real_dynamic_databin.clear(); 
 
-    // save f domain diode response in fdiode_real_dynamic_databin
+    //! save f domain diode response in fdiode_real_dynamic_databin
     for (int i = 0; i < pad_len * 2; i++) {
         fdiode_real_dynamic_databin.push_back( diode_real_fft[i] );
     }

--- a/Detector.cc
+++ b/Detector.cc
@@ -5071,7 +5071,30 @@ void Detector::get_NewDiodeModel(Settings *settings1) {
 
 }
 
+//! repadding diode value based on input pad length
+void Detector::get_NewDynamicDiodeModel(int pad_len) {
 
+    double diode_real_fft[pad_len * 2]; ///< double sized array for myconvlv
+
+    for (int i = 0; i < pad_len * 2; i++) {  // 512 bin added for zero padding
+        if ( i < (int)(maxt_diode / TIMESTEP) ) {
+            diode_real_fft[i] = diode_real[i];
+        } else {
+            diode_real_fft[i] = 0.;
+        }
+    }
+
+    // forward FFT
+    Tools::realft(diode_real_fft, 1, pad_len * 2);
+
+    // clear previous data as we need new diode response array for new pad_len
+    fdiode_real_dynamic_databin.clear(); 
+
+    // save f domain diode response in fdiode_real_dynamic_databin
+    for (int i = 0; i < pad_len * 2; i++) {
+        fdiode_real_dynamic_databin.push_back( diode_real_fft[i] );
+    }
+}
 
 void Detector::PrepareVectorsInstalled(){
     ARA_station temp_station;

--- a/Detector.h
+++ b/Detector.h
@@ -405,6 +405,7 @@ class Detector {
         double GetFreq(int bin) {return Freq[bin]*1.e6;} //from MHz to Hz
 
         vector <double> diode_real; // NFOUR/2 array of t domain tunnel diode response. same with icemc -> anita -> diode_real  but only full bandwidth array 4
+        vector <double> fdiode_real_dynamic_databin;    ///< dynamic length array of f domain tunnel diode response (FFT of diode_real). MK added -2023-05-22-
         vector <double> fdiode_real_databin;    // NFOUR array of f domain tunnel diode response (FFT of diode_real). also same with icemc -> anita -> fdiode_real  but only full bandwidth array 4
         vector <double> fdiode_real;    // NFOUR/2 array of f domain tunnel diode response (FFT of diode_real). also same with icemc -> anita -> fdiode_real  but only full bandwidth array 4
         vector <double> fdiode_real_double;    // NFOUR array of f domain tunnel diode response (FFT of diode_real). also same with icemc -> anita -> fdiode_real  but only full bandwidth array 4
@@ -429,6 +430,8 @@ class Detector {
         // this is a test version for getting new noise waveforms for each event
         // for a best performance, we can just set a new reasonable DATA_BIN_SIZE and make new values for those
         void get_NewDiodeModel(Settings *settings1);
+        
+        void get_NewDynamicDiodeModel(int pad_len); ///< repadding diode value based on input pad length. MK added -2023-05-22-
 
         void ReadFilter_New(Settings *settings1);    // get filter vector array with new DATA_BIN_SIZE 
 

--- a/Detector.h
+++ b/Detector.h
@@ -236,18 +236,15 @@ class Detector {
         void ReadFilter(string filename, Settings *settings1);
         double FilterGain[freq_step_max];   // Filter gain (dB) for Detector freq bin array
         vector <double> FilterGain_databin;   // Filter gain (dB) for DATA_BIN_SIZE bin array
-        vector <double> FilterGain_NFOUR;   // Filter gain (dB) for NFOUR bin array
 
         void ReadPreamp(string filename, Settings *settings1);
         double PreampGain[freq_step_max];   // Filter gain (dB) for Detector freq bin array
         vector <double> PreampGain_databin;   // Filter gain (dB) for DATA_BIN_SIZE bin array
-        vector <double> PreampGain_NFOUR;   // Filter gain (dB) for NFOUR bin array
 
 
         void ReadFOAM(string filename, Settings *settings1);
         double FOAMGain[freq_step_max];   // Filter gain (dB) for Detector freq bin array
         vector <double> FOAMGain_databin;   // Filter gain (dB) for DATA_BIN_SIZE bin array
-        vector <double> FOAMGain_NFOUR;   // Filter gain (dB) for NFOUR bin array
 
 
 
@@ -358,18 +355,15 @@ class Detector {
 
         double GetFilterGain(int bin) { return FilterGain[bin]; }   // same bin with Vgain, Hgain
         double GetFilterGain_databin(int bin) { return FilterGain_databin[bin]; }   // bin for FFT
-        double GetFilterGain_NFOUR(int bin) { return FilterGain_NFOUR[bin]; }   // bin for FFT
 
         double GetFilterGain_1D_OutZero(double freq); // interpolated output, with outside band returns zero
 
         double GetPreampGain(int bin) { return PreampGain[bin]; }   // same bin with Vgain, Hgain
         double GetPreampGain_databin(int bin) { return PreampGain_databin[bin]; }   // bin for FFT
-        double GetPreampGain_NFOUR(int bin) { return PreampGain_NFOUR[bin]; }   // bin for FFT
         double GetPreampGain_1D_OutZero(double freq);
 
         double GetFOAMGain(int bin) { return FOAMGain[bin]; }   // same bin with Vgain, Hgain
         double GetFOAMGain_databin(int bin) { return FOAMGain_databin[bin]; }   // bin for FFT
-        double GetFOAMGain_NFOUR(int bin) { return FOAMGain_NFOUR[bin]; }   // bin for FFT
         double GetFOAMGain_1D_OutZero(double freq);
 
 	

--- a/Report.cc
+++ b/Report.cc
@@ -4419,25 +4419,15 @@ void Report::ApplyFilter(int bin_n, Detector *detector, double &vmmhz) {  // rea
 
 }
 
-
 void Report::ApplyPreamp(int bin_n, Detector *detector, double &vmmhz) {  // read filter gain in dB and apply unitless gain to vmmhz
 
     vmmhz = vmmhz * pow(10., ( detector->GetPreampGain(bin_n) )/20.);   // from dB to unitless gain for voltage
 
 }
 
-
 void Report::ApplyFOAM(int bin_n, Detector *detector, double &vmmhz) {  // read filter gain in dB and apply unitless gain to vmmhz
 
     vmmhz = vmmhz * pow(10., ( detector->GetFOAMGain(bin_n) )/20.);   // from dB to unitless gain for voltage
-
-}
-
-
-
-void Report::ApplyFilter_NFOUR (int bin_n, Detector *detector, double &vmmhz) {  // read filter gain in dB and apply unitless gain to vmmhz
-
-    vmmhz = vmmhz * pow(10., ( detector->GetFilterGain_NFOUR(bin_n) )/20.);   // from dB to unitless gain for voltage
 
 }
 
@@ -4446,7 +4436,6 @@ void Report::ApplyFilter_OutZero (double freq, Detector *detector, double &vmmhz
     vmmhz = vmmhz * pow(10., ( detector->GetFilterGain_1D_OutZero(freq) )/20.);   // from dB to unitless gain for voltage
 
 }
-
 
 void Report::ApplyElect_Tdomain(double freq, Detector *detector, double &vm_real, double &vm_img, int gain_ch_no, Settings *settings1) {  // read elect chain gain (unitless), phase (rad) and apply to V/m
 
@@ -4501,32 +4490,11 @@ void Report::ApplyElect_Tdomain_FirstTwo(double freq0, double freq1, Detector *d
 
 }
 
-
-
-
-
-
-
-void Report::ApplyPreamp_NFOUR (int bin_n, Detector *detector, double &vmmhz) {  // read filter gain in dB and apply unitless gain to vmmhz
-
-    vmmhz = vmmhz * pow(10., ( detector->GetPreampGain_NFOUR(bin_n) )/20.);   // from dB to unitless gain for voltage
-
-}
-
-
 void Report::ApplyPreamp_OutZero (double freq, Detector *detector, double &vmmhz) {  // read filter gain in dB and apply unitless gain to vmmhz
 
     vmmhz = vmmhz * pow(10., ( detector->GetPreampGain_1D_OutZero(freq) )/20.);   // from dB to unitless gain for voltage
 
 }
-
-
-void Report::ApplyFOAM_NFOUR (int bin_n, Detector *detector, double &vmmhz) {  // read filter gain in dB and apply unitless gain to vmmhz
-
-    vmmhz = vmmhz * pow(10., ( detector->GetFOAMGain_NFOUR(bin_n) )/20.);   // from dB to unitless gain for voltage
-
-}
-
 
 void Report::ApplyFOAM_OutZero (double freq, Detector *detector, double &vmmhz) {  // read filter gain in dB and apply unitless gain to vmmhz
 
@@ -4534,14 +4502,11 @@ void Report::ApplyFOAM_OutZero (double freq, Detector *detector, double &vmmhz) 
 
 }
 
-
-
 void Report::ApplyRFCM(int ch, int bin_n, Detector *detector, double &vmmhz, double RFCM_OFFSET) {  // read RFCM gain in dB and apply unitless gain to vmmhz
 
     vmmhz = vmmhz * pow(10., ( detector->GetRFCMGain(ch,bin_n) + RFCM_OFFSET )/20.);   // from dB to unitless gain for voltage
 
 }
-
 
 void Report::ApplyFilter_databin(int bin_n, Detector *detector, double &vmmhz) {  // read filter gain in dB and apply unitless gain to vmmhz
 

--- a/Report.cc
+++ b/Report.cc
@@ -507,7 +507,7 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                                 stations[i].strings[j].antennas[k].V.resize(ray_sol_cnt + 1);
                                 stations[i].strings[j].antennas[k].SignalExt.resize(ray_sol_cnt + 1);
                                 stations[i].strings[j].antennas[k].New_NFOUR.resize(ray_sol_cnt + 1);
-                                stations[i].strings[j].antennas[k].New_NFOUR[ray_sol_cnt] = settings1->NFOUR;                             
+                                stations[i].strings[j].antennas[k].New_NFOUR[ray_sol_cnt] = settings1->NFOUR; ///< fill with default value incase there is no signal for ray solution                         
 
                                 // calculate the polarization vector at the source
                                 Pol_vector = GetPolarization(event->Nu_Interaction[0].nnu, launch_vector);
@@ -950,8 +950,6 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
 
                                                 // initially give raysol has actual signal
                                                 stations[i].strings[j].antennas[k].SignalExt[ray_sol_cnt] = 0;
-
-                                                stations[i].strings[j].antennas[k].New_NFOUR[ray_sol_cnt] = settings1->NFOUR;
 
                                                 // if no signal, push_back 0 values (otherwise the value inside will remain as old value)
                                                 for (int n = 0; n < settings1->NFOUR / 2; n++)
@@ -1926,7 +1924,7 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                         {
                             // loop over raysol numbers
                             int new_NFOUR1 = stations[i].strings[j].antennas[k].New_NFOUR[m];
-                            signal_bin.push_back((stations[i].strings[j].antennas[k].arrival_time[m] - stations[i].min_arrival_time) / (settings1->TIMESTEP) + new_NFOUR1 * 2 + trigger->maxt_diode_bin);
+                            signal_bin.push_back((stations[i].strings[j].antennas[k].arrival_time[m] - stations[i].min_arrival_time) / (settings1->TIMESTEP) + new_NFOUR_max * 2 + trigger->maxt_diode_bin);
 
                             // store signal located bin
                             stations[i].strings[j].antennas[k].SignalBin.push_back(signal_bin[m]);
@@ -3590,6 +3588,16 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
 
     }
 
+    /*
+    //debug
+    std::cout<<"signalbin1: "<<signalbin1<<std::endl;
+    std::cout<<"signalbin2: "<<signalbin2<<std::endl;
+    std::cout<<"signal_dbin: "<<signal_dbin<<std::endl;
+    std::cout<<"new_NFOUR1/4: "<<new_NFOUR1/4<<std::endl;
+    std::cout<<"new_NFOUR2/4: "<<new_NFOUR2/4<<std::endl;
+    std::cout<<"binsize: "<<BINSIZE<<std::endl;
+    */
+
     // do myconvlv and replace the diode response array
     trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real_double, V_total_forconvlv);
 
@@ -3602,7 +3610,6 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
         if ( trigger->Full_window_V[ID][bin] > settings1->V_SATURATION ) trigger->Full_window_V[ID][bin] = settings1->V_SATURATION;
         else if ( trigger->Full_window_V[ID][bin] < -1.*settings1->V_SATURATION ) trigger->Full_window_V[ID][bin] = -1.*settings1->V_SATURATION;
     }
-
 
     //V_total_forconvlv.clear();
 

--- a/Report.cc
+++ b/Report.cc
@@ -4000,9 +4000,6 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
     }
 
     // do myconvlv and replace the diode response array
-//    trigger->myconvlv( V_total_forconvlv, detector->stations[StationIndex].NFOUR, detector->stations[StationIndex].TIMESTEP, detector->fdiode_real, V_total_forconvlv);
-//    trigger->myconvlv( V_total_forconvlv, detector->stations[StationIndex].NFOUR, detector->fdiode_real, V_total_forconvlv);
-//
     trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real, V_total_forconvlv);
 
     // do replace the part we get from noise + signal
@@ -4079,9 +4076,6 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
     }
 
     // do myconvlv and replace the diode response array
-//    trigger->myconvlv( V_total_forconvlv, detector->stations[StationIndex].NFOUR, detector->stations[StationIndex].TIMESTEP, detector->fdiode_real_double, V_total_forconvlv);
-//    trigger->myconvlv( V_total_forconvlv, detector->stations[StationIndex].NFOUR, detector->fdiode_real_double, V_total_forconvlv);
-//
     trigger->myconvlv( V_total_forconvlv, BINSIZE*2, detector->fdiode_real_double, V_total_forconvlv);
 
     // do replace the part we get from noise + signal
@@ -4170,9 +4164,6 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
     }
 
     // do myconvlv and replace the diode response array
-//    trigger->myconvlv( V_total_forconvlv, detector->stations[StationIndex].NFOUR, detector->stations[StationIndex].TIMESTEP, detector->fdiode_real_double, V_total_forconvlv);
-//    trigger->myconvlv( V_total_forconvlv, detector->stations[StationIndex].NFOUR, detector->fdiode_real_double, V_total_forconvlv);
-//
     trigger->myconvlv( V_total_forconvlv, BINSIZE*2, detector->fdiode_real_double, V_total_forconvlv);
 
     // do replace the part we get from noise + signal

--- a/Report.cc
+++ b/Report.cc
@@ -3536,6 +3536,10 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
     //! do myconvlv and replace the diode response array
     if (BINSIZE == int(settings1->NFOUR / 2)) trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real, V_total_forconvlv); ///< use default diode
     else if (BINSIZE == settings1->NFOUR) trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real_double, V_total_forconvlv); ///< use default double length diode
+    else { ///< repad diode value
+        detector->get_NewDynamicDiodeModel(BINSIZE);
+        trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real_dynamic_databin, V_total_forconvlv);
+    }
 
     //! do replace the part we get from noise + signal
     for (int bin = signalbin - BINSIZE / 2 + (trigger->maxt_diode_bin); bin < signalbin + BINSIZE / 2; bin++) {
@@ -3610,6 +3614,10 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
     //! do myconvlv and replace the diode response array
     if (BINSIZE == int(settings1->NFOUR / 2)) trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real, V_total_forconvlv); ///< use default diode
     else if (BINSIZE == settings1->NFOUR) trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real_double, V_total_forconvlv); ///< use default double length diode
+    else { ///< repad diode value
+        detector->get_NewDynamicDiodeModel(BINSIZE);
+        trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real_dynamic_databin, V_total_forconvlv);
+    }
 
     //! do replace the part we get from noise + signal
     for (int bin = signalbin1 - new_NFOUR1 / 4 + (trigger->maxt_diode_bin); bin < signalbin2 + new_NFOUR2 / 4; bin++) {
@@ -3693,6 +3701,10 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
     //! do myconvlv and replace the diode response array
     if (BINSIZE == int(settings1->NFOUR / 2)) trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real, V_total_forconvlv); ///< use default diode
     else if (BINSIZE == settings1->NFOUR) trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real_double, V_total_forconvlv); ///< use default double length diode
+    else { ///< repad diode value
+        detector->get_NewDynamicDiodeModel(BINSIZE);
+        trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real_dynamic_databin, V_total_forconvlv);
+    }
 
     //! do replace the part we get from noise + signal
     for (int bin = signalbin1 - new_NFOUR1 / 4 + (trigger->maxt_diode_bin); bin < signalbin2 + new_NFOUR2 / 4; bin++) {

--- a/Report.cc
+++ b/Report.cc
@@ -921,7 +921,7 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                                                 for(int n = 0; n < new_NFOUR / 2; n++){
                                                     new_T_forint[n] = init_T + (double)n * settings1->TIMESTEP * 1.e9;
                                                 }
-                                                stations[i].strings[j].antennas[k].New_NFOUR[ray_sol_cnt].push_back(new_NFOUR); ///< save in Report branch
+                                                stations[i].strings[j].antennas[k].New_NFOUR.push_back(new_NFOUR); ///< save in Report branch
     
                                                 //! do linear interpolation
                                                 //! changed to sinc interpolation Dec 2020 by BAC
@@ -1647,8 +1647,6 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
             // calculate total number of bins we need to do trigger check
             max_total_bin = (stations[i].max_arrival_time - stations[i].min_arrival_time) / settings1->TIMESTEP + new_NFOUR_max * 3 + trigger->maxt_diode_bin;    // make more time
 
-            //stations[i].max_total_bin = max_total_bin;
-
             // test generating new noise waveform for only stations if there's any ray trace solutions
             if (settings1->NOISE_WAVEFORM_GENERATE_MODE == 0)
             {
@@ -1921,7 +1919,8 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                         for (int m = 0; m < stations[i].strings[j].antennas[k].ray_sol_cnt; m++)
                         {
                             // loop over raysol numbers
-                            signal_bin.push_back((stations[i].strings[j].antennas[k].arrival_time[m] - stations[i].min_arrival_time) / (settings1->TIMESTEP) + stations[i].strings[j].antennas[k].New_NFOUR[m] *2 + trigger->maxt_diode_bin);
+                            int new_NFOUR1 = stations[i].strings[j].antennas[k].New_NFOUR[m];
+                            signal_bin.push_back((stations[i].strings[j].antennas[k].arrival_time[m] - stations[i].min_arrival_time) / (settings1->TIMESTEP) + new_NFOUR1 * 2 + trigger->maxt_diode_bin);
 
                             // store signal located bin
                             stations[i].strings[j].antennas[k].SignalBin.push_back(signal_bin[m]);
@@ -1930,7 +1929,8 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                             {
                                 signal_dbin.push_back(signal_bin[m] - signal_bin[m - 1]);
                                 // cout<<"  signal_dbin["<<m-1<<"] : "<<signal_dbin[m-1];
-                                if ((signal_dbin[m - 1] < stations[i].strings[j].antennas[k].New_NFOUR[m - 1] / 2) || (signal_dbin[m - 1] < stations[i].strings[j].antennas[k].New_NFOUR[m] / 2))
+                                int new_NFOUR2 = stations[i].strings[j].antennas[k].New_NFOUR[m - 1];
+                                if ((signal_dbin[m - 1] < new_NFOUR2 / 2) || (signal_dbin[m - 1] < new_NFOUR1 / 2))
                                 {
                                     // if two ray_sol time delay is smaller than time window
                                     connect_signals.push_back(1);
@@ -1960,19 +1960,19 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                             if (m == 0)
                             {
                                 // if it's first sol
-
+                                int new_NFOUR1 = stations[i].strings[j].antennas[k].New_NFOUR[m];
                                 if (connect_signals[m] == 1)
                                 {
 
                                     // do two convlv with double array m, m+1
-
+                                    int new_NFOUR2 = stations[i].strings[j].antennas[k].New_NFOUR[m + 1];
                                     Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], signal_bin[m + 1], stations[i].strings[j].antennas[k].V[m], stations[i].strings[j].antennas[k].V[m + 1], noise_ID, ch_ID, i,
-                                                                stations[i].strings[j].antennas[k].New_NFOUR[m], stations[i].strings[j].antennas[k].New_NFOUR[m + 1]);
+                                                                new_NFOUR1, new_NFOUR2);
                                 }
                                 else if (connect_signals[m] == 0)
                                 {
                                     // cout << noise_ID << " : " << ch_ID << " : " << i << " : " << endl;
-                                    Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], stations[i].strings[j].antennas[k].V[m], noise_ID, ch_ID, i, stations[i].strings[j].antennas[k].New_NFOUR[m]);
+                                    Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], stations[i].strings[j].antennas[k].V[m], noise_ID, ch_ID, i, new_NFOUR1);
                                 }
                             }
                             else
@@ -1986,16 +1986,17 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                                     if (connect_signals[m] == 1)
                                     {
                                         // next raysol is connected
-
+                                        int new_NFOUR1 = stations[i].strings[j].antennas[k].New_NFOUR[m];
+                                        int new_NFOUR2 = stations[i].strings[j].antennas[k].New_NFOUR[m + 1];
                                         if (connect_signals[m - 1] == 1)
                                         {
                                             // and previous raysol also connected
 
                                             // double size array with m-1, m, m+1 raysols all added
-                                            //
+                                            int new_NFOUR0 = stations[i].strings[j].antennas[k].New_NFOUR[m - 1];
                                             Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m - 1], signal_bin[m], signal_bin[m + 1], stations[i].strings[j].antennas[k].V[m - 1], 
                                                                         stations[i].strings[j].antennas[k].V[m], stations[i].strings[j].antennas[k].V[m + 1], noise_ID, ch_ID, i,
-                                                                        stations[i].strings[j].antennas[k].New_NFOUR[m - 1], stations[i].strings[j].antennas[k].New_NFOUR[m], stations[i].strings[j].antennas[k].New_NFOUR[m + 1]);
+                                                                        new_NFOUR0, new_NFOUR1, new_NFOUR2);
                                         }
                                         else if (connect_signals[m - 1] == 0)
                                         {
@@ -2004,7 +2005,7 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                                             // double size array with m, m+1 raysols
                                             //
                                             Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], signal_bin[m + 1], stations[i].strings[j].antennas[k].V[m], stations[i].strings[j].antennas[k].V[m + 1], 
-                                                                        noise_ID, ch_ID, i, stations[i].strings[j].antennas[k].New_NFOUR[m], stations[i].strings[j].antennas[k].New_NFOUR[m + 1]);
+                                                                        noise_ID, ch_ID, i, new_NFOUR1, new_NFOUR2);
                                         }
                                     }
                                     else if (connect_signals[m] == 0)
@@ -2024,8 +2025,8 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                                             // and previous raysol not connected
 
                                             // single size array with only m raysol
-                                            //
-                                            Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], stations[i].strings[j].antennas[k].V[m], noise_ID, ch_ID, i, stations[i].strings[j].antennas[k].New_NFOUR[m]);
+                                            int new_NFOUR1 = stations[i].strings[j].antennas[k].New_NFOUR[m];
+                                            Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], stations[i].strings[j].antennas[k].V[m], noise_ID, ch_ID, i, new_NFOUR1);
                                         }
                                     }
                                 }
@@ -2046,8 +2047,8 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                                         // and previous raysol is not connected
 
                                         // single size array with only m raysol
-                                        //
-                                        Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], stations[i].strings[j].antennas[k].V[m], noise_ID, ch_ID, i, stations[i].strings[j].antennas[k].New_NFOUR[m]);
+                                        int new_NFOUR1 = stations[i].strings[j].antennas[k].New_NFOUR[m];
+                                        Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], stations[i].strings[j].antennas[k].V[m], noise_ID, ch_ID, i, new_NFOUR1);
                                     }
                                 }
                             }   // if not the first raysol (all other raysols)
@@ -2097,16 +2098,13 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                 // save trig search bin info default (if no global trig, this value saved)
                 stations[i].total_trig_search_bin = max_total_bin - trig_search_init;
 
-                if (settings1->TRIG_SCAN_MODE == 0)
-                {
+                if (settings1->TRIG_SCAN_MODE == 0) {
                     // ********************old mode left as-is ********************
 
                     // avoid really long trig_window_bin case (change trig_window to check upto max_total_bin)
                     if (max_total_bin - trig_window_bin <= trig_i) trig_window_bin = max_total_bin - trig_i - 1;
 
-                    //while (trig_i < settings1->DATA_BIN_SIZE - trig_window_bin) {
-                    while (trig_i < max_total_bin - trig_window_bin)
-                    {
+                    while (trig_i < max_total_bin - trig_window_bin) {
 
                         N_pass = 0;
                         N_pass_V = 0;
@@ -2116,8 +2114,7 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
 
                         //for (trig_j=0; trig_j < ch_ID; trig_j++) {        // loop over all channels
                         trig_j = 0;
-                        while (trig_j < ch_ID)
-                        {
+                        while (trig_j < ch_ID) {
 
                             int string_i = detector->getStringfromArbAntID(i, trig_j);
                             int antenna_i = detector->getAntennafromArbAntID(i, trig_j);
@@ -2181,196 +2178,101 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                             }
                             // check all triggered channels not just 3
                             trig_j++;   // if station not passed the trigger, just go to next channel
-
                         }   // while trig_j < ch_ID
 
-                        //if (N_pass > settings1->N_TRIG-1) {   // now as global trigged!! = more or eq to N_TRIG triggered
                         if (((trig_mode == 0) && (N_pass > settings1->N_TRIG - 1))  // trig_mode = 0 case!
                             ||  // or
-                            ((trig_mode == 1) && ((N_pass_V > settings1->N_TRIG_V - 1) || (N_pass_H > settings1->N_TRIG_H - 1)))    // trig_mode = 1 case!
-                       )
-                        {
+                            ((trig_mode == 1) && ((N_pass_V > settings1->N_TRIG_V - 1) || (N_pass_H > settings1->N_TRIG_H - 1)))) {    // trig_mode = 1 case!
 
                             check_ch = 0;
                             stations[i].Global_Pass = last_trig_bin;    // where actually global trigger occured
 
                             trig_i = max_total_bin; // also if we know this station is trigged, don't need to check rest of time window
-                            for (int ch_loop = 0; ch_loop < ch_ID; ch_loop++)
-                            {
+                            for (int ch_loop = 0; ch_loop < ch_ID; ch_loop++) {
                                 //cout << ch_loop << "/" << ch_ID << endl;
                                 int string_i = detector->getStringfromArbAntID(i, ch_loop);
                                 int antenna_i = detector->getAntennafromArbAntID(i, ch_loop);
                                 //          cout << "string:antenna: " << string_i << " : " << antenna_i << endl;
                                 stations[i].strings[string_i].antennas[antenna_i].Likely_Sol = -1;  // no likely init
-                                if (ch_loop == Passed_chs[check_ch] && check_ch < N_pass)
-                                {
+
+                                if (ch_loop == Passed_chs[check_ch] && check_ch < N_pass) {
                                     // added one more condition (check_ch < N_Pass) for bug in vector Passed_chs.clear()???
-
                                     // store which ray sol is triggered based on trig time
-                                    //
-
                                     int mindBin = 1.e9; // init big value
                                     int dBin = 0;
+                                    int trig_pass = stations[i].strings[string_i].antennas[antenna_i].Trig_Pass;
 
-                                    for (int m = 0; m < stations[i].strings[string_i].antennas[antenna_i].ray_sol_cnt; m++)
-                                    {
+                                    for (int m = 0; m < stations[i].strings[string_i].antennas[antenna_i].ray_sol_cnt; m++) {
                                         // loop over raysol numbers
-
-                                        if (stations[i].strings[string_i].antennas[antenna_i].SignalExt[m])
-                                        {
-
-                                            dBin = abs(stations[i].strings[string_i].antennas[antenna_i].SignalBin[m] - stations[i].strings[string_i].antennas[antenna_i].Trig_Pass);
-
-                                            if (dBin < mindBin)
-                                            {
+                                        if (stations[i].strings[string_i].antennas[antenna_i].SignalExt[m]) {
+                                            dBin = abs(stations[i].strings[string_i].antennas[antenna_i].SignalBin[m] - trig_pass);
+                                            if (dBin < mindBin) {
                                                 stations[i].strings[string_i].antennas[antenna_i].Likely_Sol = m;   // store the ray sol number which is minimum difference between Trig_Pass bin
                                                 mindBin = dBin;
                                             }
                                         }
                                     }
-
+    
+                                    int ant_types = detector->stations[i].strings[string_i].antennas[antenna_i].type;
+                                    double posnu_d = event->Nu_Interaction[0].posnu.Distance(detector->stations[i].strings[string_i].antennas[antenna_i]);
+                                    int noise_id = stations[i].strings[string_i].antennas[antenna_i].noise_ID[0];
+                                    int likely_sol = stations[i].strings[string_i].antennas[antenna_i].Likely_Sol;
                                     //skip this passed ch as it already has bin info
-                                    if (settings1->TRIG_ONLY_LOW_CH_ON == 0)
-                                    {
-                                        cout << endl << "trigger passed at bin " << stations[i].strings[string_i].antennas[antenna_i].Trig_Pass << "  passed ch : " << ch_loop << " (" << detector->stations[i].strings[string_i].antennas[antenna_i].type << "type) Direct dist btw posnu : " << event->Nu_Interaction[0].posnu.Distance(detector->stations[i].strings[string_i].antennas[antenna_i]) << " noiseID : " << stations[i].strings[string_i].antennas[antenna_i].noise_ID[0];
-                                        if (stations[i].strings[string_i].antennas[antenna_i].Likely_Sol != -1)
-                                        {
-                                            cout << " ViewAngle : " << stations[i].strings[string_i].antennas[antenna_i].view_ang[0] *DEGRAD << " LikelyTrigSignal : " << stations[i].strings[string_i].antennas[antenna_i].Likely_Sol;
-                                        }
+                                    if (settings1->TRIG_ONLY_LOW_CH_ON == 0) {
+                                        cout << endl << "trigger passed at bin " << trig_pass << "  passed ch : " << ch_loop << " (" << ant_types << "type) Direct dist btw posnu : " << posnu_d << " noiseID : " << noise_id;
+                                    } else if (settings1->TRIG_ONLY_LOW_CH_ON == 1) {
+                                        cout << endl << "trigger passed at bin " << trig_pass << "  passed ant: str[" << string_i << "].ant[" << antenna_i << "] (" << ant_types << "type) Direct dist btw posnu : " << posnu_d << " noiseID : " << noise_id;
                                     }
-                                    else if (settings1->TRIG_ONLY_LOW_CH_ON == 1)
-                                    {
-                                        cout << endl << "trigger passed at bin " << stations[i].strings[string_i].antennas[antenna_i].Trig_Pass << "  passed ant: str[" << string_i << "].ant[" << antenna_i << "] (" << detector->stations[i].strings[string_i].antennas[antenna_i].type << "type) Direct dist btw posnu : " << event->Nu_Interaction[0].posnu.Distance(detector->stations[i].strings[string_i].antennas[antenna_i]) << " noiseID : " << stations[i].strings[string_i].antennas[antenna_i].noise_ID[0];
-                                        if (stations[i].strings[string_i].antennas[antenna_i].Likely_Sol != -1)
-                                        {
-                                            cout << " ViewAngle : " << stations[i].strings[string_i].antennas[antenna_i].view_ang[0] *DEGRAD << " LikelyTrigSignal : " << stations[i].strings[string_i].antennas[antenna_i].Likely_Sol;
-                                        }
-                                    }
+                                    if (likely_sol != -1) {
+                                        cout << " ViewAngle : " << stations[i].strings[string_i].antennas[antenna_i].view_ang[0] *DEGRAD << " LikelyTrigSignal : " << likely_sol;
+                                    }                                    
 
                                     //cout << "True station number: " << detector->InstalledStations[0].VHChannel[string_i][antenna_i] << endl;
                                     //cout << event->Nu_Interaction[0].posnu[0] << " : " <<  event->Nu_Interaction[0].posnu[1] << " : " << event->Nu_Interaction[0].posnu[2] << endl;
                                     check_ch++;
-
-                                    // now save the voltage waveform to V_mimic
-                                    //
-
-                                    for (int mimicbin = 0; mimicbin < waveformLength; mimicbin++)
-                                    {
-
-                                        // new DAQ waveform writing mechanism test
-                                        if (V_mimic_mode == 0)
-                                        {
-                                            // Global passed bin is the center of the window
-                                            stations[i].strings[string_i].antennas[antenna_i].V_mimic.push_back((trigger->Full_window_V[ch_loop][last_trig_bin + waveformCenter - waveformLength / 2 + mimicbin]) *1.e3);   // save in mV
-                                            stations[i].strings[string_i].antennas[antenna_i].time.push_back(last_trig_bin + waveformCenter - waveformLength / 2 + mimicbin);
-                                            stations[i].strings[string_i].antennas[antenna_i].time_mimic.push_back((waveformCenter - waveformLength / 2 + mimicbin) *settings1->TIMESTEP *1.e9);    // save in ns
-                                        }
-                                        else if (V_mimic_mode == 1)
-                                        {
-                                            // Global passed bin is the center of the window + delay to each chs from araGeom
-                                            stations[i].strings[string_i].antennas[antenna_i].V_mimic.push_back((trigger->Full_window_V[ch_loop][last_trig_bin - (detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin) + waveformCenter - waveformLength / 2 + mimicbin]) *1.e3);   // save in mV
-                                            stations[i].strings[string_i].antennas[antenna_i].time.push_back(last_trig_bin - (detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin) + waveformCenter - waveformLength / 2 + mimicbin);
-                                            stations[i].strings[string_i].antennas[antenna_i].time_mimic.push_back((-(detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin) + waveformCenter - waveformLength / 2 + mimicbin) *settings1->TIMESTEP *1.e9);   // save in ns
-                                        }
-                                        else if (V_mimic_mode == 2)
-                                        {
-                                            // Global passed bin is the center of the window + delay to each chs from araGeom + fitted by eye
-                                            stations[i].strings[string_i].antennas[antenna_i].V_mimic.push_back((trigger->Full_window_V[ch_loop][last_trig_bin - (detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin + detector->stations[i].strings[string_i].antennas[antenna_i].manual_delay_bin) + waveformCenter - waveformLength / 2 + mimicbin]) *1.e3);    // save in mV
-                                            stations[i].strings[string_i].antennas[antenna_i].time.push_back(last_trig_bin - (detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin + detector->stations[i].strings[string_i].antennas[antenna_i].manual_delay_bin) + waveformCenter - waveformLength / 2 + mimicbin);
-                                            stations[i].strings[string_i].antennas[antenna_i].time_mimic.push_back((-(detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin + detector->stations[i].strings[string_i].antennas[antenna_i].manual_delay_bin) + waveformCenter - waveformLength / 2 + mimicbin) *settings1->TIMESTEP *1.e9 + detector->params.TestBed_WFtime_offset_ns);    // save in ns
-                                        }
-                                        if (mimicbin == 0) {
-                                            for (int m = 0; m < stations[i].strings[string_i].antennas[antenna_i].ray_sol_cnt; m++) { ///< calculates time of center of each rays signal based on readout window time config
-                                                double signal_center_offset = (double)(stations[i].strings[string_i].antennas[antenna_i].SignalBin[m] - stations[i].strings[string_i].antennas[antenna_i].time[0]) * settings1->TIMESTEP * 1.e9;
-                                                double signal_center_time = signal_center_offset + stations[i].strings[string_i].antennas[antenna_i].time_mimic[0];
-                                                //! signal_center_offset: time offset between beginning of readout window and center of signal
-                                                //! signal_center_time: time of center of signal based on readout window time config
-                                                stations[i].strings[string_i].antennas[antenna_i].SignalBinTime.push_back(signal_center_time);
-                                            }
-                                        }
-                                    }
-
-                                    // set global_trig_bin values
-                                    if (V_mimic_mode == 0)
-                                    {
-                                        // Global passed bin is the center of the window
-                                        stations[i].strings[string_i].antennas[antenna_i].global_trig_bin = (waveformLength / 2 - waveformCenter);
-                                    }
-                                    else if (V_mimic_mode == 1)
-                                    {
-                                        // Global passed bin is the center of the window + delay to each chs from araGeom
-                                        stations[i].strings[string_i].antennas[antenna_i].global_trig_bin = (detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin) - waveformCenter + waveformLength / 2;
-                                    }
-                                    else if (V_mimic_mode == 2)
-                                    {
-                                        // Global passed bin is the center of the window + delay to each chs from araGeom + fitted by eye
-                                        stations[i].strings[string_i].antennas[antenna_i].global_trig_bin = (detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin + detector->stations[i].strings[string_i].antennas[antenna_i].manual_delay_bin) - waveformCenter + waveformLength / 2;
-                                    }
-                                }
-                                else
-                                {
+                                } else {
                                     stations[i].strings[string_i].antennas[antenna_i].Trig_Pass = 0.;
+                                }
+                                // now save the voltage waveform to V_mimic
+                                int time_bin_i = waveformCenter - waveformLength / 2;
+                                int testbed_ch_delay = detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin;
+                                int manual_delay_bins = detector->stations[i].strings[string_i].antennas[antenna_i].manual_delay_bin;
+                                
+                                // new DAQ waveform writing mechanism test
+                                for (int mimicbin = 0; mimicbin < waveformLength; mimicbin++) {
 
                                     // new DAQ waveform writing mechanism test
-                                    for (int mimicbin = 0; mimicbin < waveformLength; mimicbin++)
-                                    {
-                                        if (V_mimic_mode == 0)
-                                        {
-                                            // Global passed bin is the center of the window
-                                            stations[i].strings[string_i].antennas[antenna_i].V_mimic.push_back((trigger->Full_window_V[ch_loop][last_trig_bin + waveformCenter - waveformLength / 2 + mimicbin]) *1.e3);   // save in mV
-                                            stations[i].strings[string_i].antennas[antenna_i].time.push_back(last_trig_bin + waveformCenter - waveformLength / 2 + mimicbin);
-                                            stations[i].strings[string_i].antennas[antenna_i].time_mimic.push_back((waveformCenter - waveformLength / 2 + mimicbin) *settings1->TIMESTEP *1.e9);    // save in ns
-                                        }
-                                        else if (V_mimic_mode == 1)
-                                        {
-                                            // Global passed bin is the center of the window + delay to each chs from araGeom
-                                            stations[i].strings[string_i].antennas[antenna_i].V_mimic.push_back((trigger->Full_window_V[ch_loop][last_trig_bin - (detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin) + waveformCenter - waveformLength / 2 + mimicbin]) *1.e3);   // save in mV
-                                            stations[i].strings[string_i].antennas[antenna_i].time.push_back(last_trig_bin - (detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin) + waveformCenter - waveformLength / 2 + mimicbin);
-                                            stations[i].strings[string_i].antennas[antenna_i].time_mimic.push_back((-(detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin) + waveformCenter - waveformLength / 2 + mimicbin) *settings1->TIMESTEP *1.e9);   // save in ns
-                                        }
-                                        if (V_mimic_mode == 2)
-                                        {
-                                            // Global passed bin is the center of the window + delay to each chs from araGeom + fitted delay
-                                            stations[i].strings[string_i].antennas[antenna_i].V_mimic.push_back((trigger->Full_window_V[ch_loop][last_trig_bin - (detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin + detector->stations[i].strings[string_i].antennas[antenna_i].manual_delay_bin) + waveformCenter - waveformLength / 2 + mimicbin]) *1.e3);    // save in mV
-                                            stations[i].strings[string_i].antennas[antenna_i].time.push_back(last_trig_bin - (detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin + detector->stations[i].strings[string_i].antennas[antenna_i].manual_delay_bin) + waveformCenter - waveformLength / 2 + mimicbin);
-                                            stations[i].strings[string_i].antennas[antenna_i].time_mimic.push_back((-(detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin + detector->stations[i].strings[string_i].antennas[antenna_i].manual_delay_bin) + waveformCenter - waveformLength / 2 + mimicbin) *settings1->TIMESTEP *1.e9 + detector->params.TestBed_WFtime_offset_ns);    // save in ns
-                                        }
-                                        if (mimicbin == 0) {
-                                            for (int m = 0; m < stations[i].strings[string_i].antennas[antenna_i].ray_sol_cnt; m++) { ///< calculates time of center of each rays signal based on readout window time config
-                                                double signal_center_offset = (double)(stations[i].strings[string_i].antennas[antenna_i].SignalBin[m] - stations[i].strings[string_i].antennas[antenna_i].time[0]) * settings1->TIMESTEP * 1.e9;
-                                                double signal_center_time = signal_center_offset + stations[i].strings[string_i].antennas[antenna_i].time_mimic[0];
-                                                //! signal_center_offset: time offset between beginning of readout window and center of signal
-                                                //! signal_center_time: time of center of signal based on readout window time config
-                                                stations[i].strings[string_i].antennas[antenna_i].SignalBinTime.push_back(signal_center_time);
-                                            }
-                                        }
+                                    int time_bin = time_bin_i + mimicbin;
+                                    int wf_bin = last_trig_bin + time_bin;
+                                    if (V_mimic_mode == 1 || V_mimic_mode == 2) {
+                                        wf_bin -= testbed_ch_delay;
+                                        time_bin -= testbed_ch_delay;
                                     }
+                                    if (V_mimic_mode == 2) wf_bin -= manual_delay_bins;
+                                    double time_mimic_val = (double)time_bin * settings1->TIMESTEP * 1.e9;
+                                    if (V_mimic_mode == 2) time_mimic_val += detector->params.TestBed_WFtime_offset_ns;
 
-                                    // set global_trig_bin values
-                                    if (V_mimic_mode == 0)
-                                    {
-                                        // Global passed bin is the center of the window
-                                        stations[i].strings[string_i].antennas[antenna_i].global_trig_bin = waveformLength / 2 - waveformCenter;
-                                    }
-                                    else if (V_mimic_mode == 1)
-                                    {
-                                        // Global passed bin is the center of the window + delay to each chs from araGeom
-                                        stations[i].strings[string_i].antennas[antenna_i].global_trig_bin = (detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin) + waveformLength / 2 - waveformCenter;
-                                    }
-                                    else if (V_mimic_mode == 2)
-                                    {
-                                        // Global passed bin is the center of the window + delay to each chs from araGeom + fitted by eye
-                                        stations[i].strings[string_i].antennas[antenna_i].global_trig_bin = (detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin + detector->stations[i].strings[string_i].antennas[antenna_i].manual_delay_bin) + waveformLength / 2 - waveformCenter;
-                                    }
+                                    stations[i].strings[string_i].antennas[antenna_i].V_mimic.push_back(trigger->Full_window_V[ch_loop][wf_bin] * 1.e3);   // save in mV
+                                    stations[i].strings[string_i].antennas[antenna_i].time.push_back(wf_bin);
+                                    stations[i].strings[string_i].antennas[antenna_i].time_mimic.push_back(time_mimic_val);    // save in ns
 
-                                    // done V_mimic for non-triggered chs (done fixed V_mimic)
+                                    if (mimicbin == 0) {
+                                        for (int m = 0; m < stations[i].strings[string_i].antennas[antenna_i].ray_sol_cnt; m++) { ///< calculates time of center of each rays signal based on readout window time config
+                                            //! time offset between beginning of readout window and center of signal
+                                            double signal_center_offset = (double)(stations[i].strings[string_i].antennas[antenna_i].SignalBin[m] - wf_bin) * settings1->TIMESTEP * 1.e9;
+                                            //! time of center of signal based on readout window time config
+                                            double signal_center_time = signal_center_offset + time_mimic_val;
+                                            stations[i].strings[string_i].antennas[antenna_i].SignalBinTime.push_back(signal_center_time);
+                                        }
+                                    }
                                 }
 
-                                double arrivtime = stations[i].strings[string_i].antennas[antenna_i].arrival_time[0];
-                                double X = detector->stations[i].strings[string_i].antennas[antenna_i].GetX();
-                                double Y = detector->stations[i].strings[string_i].antennas[antenna_i].GetY();
-                                double Z = detector->stations[i].strings[string_i].antennas[antenna_i].GetZ();
-                                //std::cout << "Arrival time:X:Y:Z " << arrivtime << " : " << X << " : " << Y << " : " << Z << std::endl;
+                                // set global_trig_bin values
+                                // Global passed bin is the center of the window
+                                int global_trig_bins = -1 * time_bin_i; // if (V_mimic_mode == 0) Global passed bin is the center of the window
+                                if (V_mimic_mode == 1 || V_mimic_mode == 2) global_trig_bins += testbed_ch_delay; // Global passed bin is the center of the window + delay to each chs from araGeom
+                                if (V_mimic_mode == 2) global_trig_bins += manual_delay_bins; // Global passed bin is the center of the window + delay to each chs from araGeom + fitted by eye
+                                stations[i].strings[string_i].antennas[antenna_i].global_trig_bin = global_trig_bins;
                             }
 
                             //cout<<"Global trigger passed!!, N_pass : "<<N_pass<<endl;
@@ -2379,8 +2281,7 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                             // save trig search bin info
                             stations[i].total_trig_search_bin = stations[i].Global_Pass + trig_window_bin - trig_search_init;
                         }   // if global trig!
-                        else
-                        {
+                        else {
                             trig_i++;   // also if station not passed the trigger, just go to next bin
                         }
                     }   // while trig_i
@@ -3707,7 +3608,7 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
 
 
 // this one is for three connected signals 
-void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin0, int signalbin1, int signalbin2, vector <double> &V0, vector <double> &V1, vector <double> &V2, int *noise_ID, int ID, int StationIndex, int new_NFOUR1, int new_NFOUR2, int new_NFOUR3) {
+void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin0, int signalbin1, int signalbin2, vector <double> &V0, vector <double> &V1, vector <double> &V2, int *noise_ID, int ID, int StationIndex, int new_NFOUR0, int new_NFOUR1, int new_NFOUR2) {
 
     int bin_value;
     int signal_dbin = signalbin2 - signalbin1;

--- a/Report.cc
+++ b/Report.cc
@@ -913,7 +913,8 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                                                 int new_NFOUR = settings1->NFOUR;
                                                 if (settings1->DYNAMIC_NFOUR == 1) {
                                                     new_NFOUR = ((int)(pad_len / 4) + 1) * 4; ///< slightly longer, but also can be divided by 4
-
+                                                }
+    
                                                 //! do linear interpolation
                                                 //! changed to sinc interpolation Dec 2020 by BAC
                                                 Tools::SincInterpolation(pad_len, T_forfft, V_forfft, new_NFOUR / 2, T_forint, volts_forint);

--- a/Report.cc
+++ b/Report.cc
@@ -1966,13 +1966,14 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
 
                                     // do two convlv with double array m, m+1
 
-                                    Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], signal_bin[m + 1], stations[i].strings[j].antennas[k].V[m], stations[i].strings[j].antennas[k].V[m + 1], noise_ID, ch_ID, i);
+                                    Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], signal_bin[m + 1], stations[i].strings[j].antennas[k].V[m], stations[i].strings[j].antennas[k].V[m + 1], noise_ID, ch_ID, i,
+                                                                stations[i].strings[j].antennas[k].New_NFOUR[m], stations[i].strings[j].antennas[k].New_NFOUR[m + 1]);
                                 }
                                 else if (connect_signals[m] == 0)
                                 {
                                     // cout << noise_ID << " : " << ch_ID << " : " << i << " : " << endl;
                                     // do NFOUR/2 size array convlv (m)
-                                    Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], stations[i].strings[j].antennas[k].V[m], noise_ID, ch_ID, i);
+                                    Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], stations[i].strings[j].antennas[k].V[m], noise_ID, ch_ID, i, stations[i].strings[j].antennas[k].New_NFOUR[m]);
                                 }
                             }
                             else
@@ -1993,7 +1994,9 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
 
                                             // double size array with m-1, m, m+1 raysols all added
                                             //
-                                            Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m - 1], signal_bin[m], signal_bin[m + 1], stations[i].strings[j].antennas[k].V[m - 1], stations[i].strings[j].antennas[k].V[m], stations[i].strings[j].antennas[k].V[m + 1], noise_ID, ch_ID, i);
+                                            Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m - 1], signal_bin[m], signal_bin[m + 1], stations[i].strings[j].antennas[k].V[m - 1], 
+                                                                        stations[i].strings[j].antennas[k].V[m], stations[i].strings[j].antennas[k].V[m + 1], noise_ID, ch_ID, i,
+                                                                        stations[i].strings[j].antennas[k].New_NFOUR[m - 1], stations[i].strings[j].antennas[k].New_NFOUR[m], stations[i].strings[j].antennas[k].New_NFOUR[m + 1]);
                                         }
                                         else if (connect_signals[m - 1] == 0)
                                         {
@@ -2001,7 +2004,8 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
 
                                             // double size array with m, m+1 raysols
                                             //
-                                            Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], signal_bin[m + 1], stations[i].strings[j].antennas[k].V[m], stations[i].strings[j].antennas[k].V[m + 1], noise_ID, ch_ID, i);
+                                            Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], signal_bin[m + 1], stations[i].strings[j].antennas[k].V[m], stations[i].strings[j].antennas[k].V[m + 1], 
+                                                                        noise_ID, ch_ID, i, stations[i].strings[j].antennas[k].New_NFOUR[m], stations[i].strings[j].antennas[k].New_NFOUR[m + 1]);
                                         }
                                     }
                                     else if (connect_signals[m] == 0)
@@ -2022,7 +2026,7 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
 
                                             // single size array with only m raysol
                                             //
-                                            Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], stations[i].strings[j].antennas[k].V[m], noise_ID, ch_ID, i);
+                                            Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], stations[i].strings[j].antennas[k].V[m], noise_ID, ch_ID, i, stations[i].strings[j].antennas[k].New_NFOUR[m]);
                                         }
                                     }
                                 }
@@ -2044,7 +2048,7 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
 
                                         // single size array with only m raysol
                                         //
-                                        Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], stations[i].strings[j].antennas[k].V[m], noise_ID, ch_ID, i);
+                                        Select_Wave_Convlv_Exchange(settings1, trigger, detector, signal_bin[m], stations[i].strings[j].antennas[k].V[m], noise_ID, ch_ID, i, stations[i].strings[j].antennas[k].New_NFOUR[m]);
                                     }
                                 }
                             }   // if not the first raysol (all other raysols)
@@ -3904,18 +3908,16 @@ void Report::ClearUselessfromConnect(Detector *detector, Settings *settings1, Tr
 
 
 // this one is for single signal
-void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin, vector <double> &V, int *noise_ID, int ID, int StationIndex) {
+void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin, vector <double> &V, int *noise_ID, int ID, int StationIndex, int new_NFOUR) {
 
-    int BINSIZE = settings1->NFOUR/2;
+    int BINSIZE = new_NFOUR / 2;
 
-//    int BINSIZE = detector->stations[StationIndex].NFOUR/2;
     int bin_value;
-    //vector <double> V_total_forconvlv;   // total time domain waveform (noise + signal)
     
     V_total_forconvlv.clear();
     
     // first, fill the noise values
-    for (int bin=0; bin<BINSIZE; bin++) {   //BINSIZE should be NFOUR/2
+    for (int bin=0; bin<BINSIZE; bin++) { 
         bin_value = signalbin - BINSIZE/2 + bin;
 
         // save the noise + signal waveform
@@ -3943,11 +3945,10 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
     trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real, V_total_forconvlv);
 
     // do replace the part we get from noise + signal
-    for (int bin=signalbin-BINSIZE/2+(trigger->maxt_diode_bin); bin<signalbin+BINSIZE/2; bin++) {
+    for (int bin = signalbin - BINSIZE / 2 + (trigger->maxt_diode_bin); bin < signalbin + BINSIZE / 2; bin++) {
         trigger->Full_window[ID][bin] = V_total_forconvlv[bin - signalbin + BINSIZE/2];
         trigger->Full_window_V[ID][bin] += V[bin - signalbin + BINSIZE/2];
 
-        //
         // electronics saturation effect
         if ( trigger->Full_window_V[ID][bin] > settings1->V_SATURATION ) trigger->Full_window_V[ID][bin] = settings1->V_SATURATION;
         else if ( trigger->Full_window_V[ID][bin] < -1.*settings1->V_SATURATION ) trigger->Full_window_V[ID][bin] = -1.*settings1->V_SATURATION;
@@ -3963,24 +3964,21 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
 
 
 // this one is for two connected signals 
-void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin1, int signalbin2, vector <double> &V1, vector <double> &V2, int *noise_ID, int ID, int StationIndex) {
+void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin1, int signalbin2, vector <double> &V1, vector <double> &V2, int *noise_ID, int ID, int StationIndex, int new_NFOUR1, int new_NFOUR2) {
 
-    int BINSIZE = settings1->NFOUR/2;
-
-//    int BINSIZE = detector->stations[StationIndex].NFOUR/2;
     int bin_value;
     int signal_dbin = signalbin2 - signalbin1;
-    //vector <double> V_total_forconvlv;   // total time domain waveform (noise + signal)
-    double V_tmp[BINSIZE*2];
-    for(int bin_tmp=0; bin_tmp<BINSIZE*2; bin_tmp++) {
+    int BINSIZE = new_NFOUR1 / 4 + signal_dbin + new_NFOUR2 / 4;
+    double V_tmp[BINSIZE];
+    for(int bin_tmp=0; bin_tmp<BINSIZE; bin_tmp++) {
         V_tmp[bin_tmp] = 0.;
     }
     
     V_total_forconvlv.clear();
     
     // first, fill the noise values
-    for (int bin=0; bin<BINSIZE*2; bin++) {
-        bin_value = signalbin1 - BINSIZE/2 + bin;
+    for (int bin=0; bin<BINSIZE; bin++) {
+        bin_value = signalbin1 - new_NFOUR1 / 4 + bin;
 
         // save the noise waveform
         if ( settings1->NOISE_CHANNEL_MODE==0) {
@@ -4000,29 +3998,29 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
 
 
         // exchange from pure noise to noise + signal
-        if (bin < signal_dbin) {  // bins where only first signal is shown
+        if (bin < (BINSIZE - new_NFOUR2 / 2)) {  // bins where only first signal is shown
             V_total_forconvlv[bin] = V_total_forconvlv[bin] + V1[bin];
             V_tmp[bin] = V1[bin];
         }
-        else if (bin < BINSIZE) { // bins where first + second signal is shown
-            V_total_forconvlv[bin] = V_total_forconvlv[bin] + V1[bin] + V2[bin - signal_dbin];
-            V_tmp[bin] = V1[bin] + V2[bin - signal_dbin];
+        else if (bin < new_NFOUR1 / 2) { // bins where first + second signal is shown
+            V_total_forconvlv[bin] = V_total_forconvlv[bin] + V1[bin] + V2[bin - (BINSIZE - new_NFOUR2 / 2)];
+            V_tmp[bin] = V1[bin] + V2[bin - (BINSIZE - new_NFOUR2 / 2)];
         }
-        else if (bin < BINSIZE + signal_dbin) { // bins where only second signal is shown
-            V_total_forconvlv[bin] = V_total_forconvlv[bin] + V2[bin - signal_dbin];
-            V_tmp[bin] = V2[bin - signal_dbin];
+        else { // bins where only second signal is shown
+            V_total_forconvlv[bin] = V_total_forconvlv[bin] + V2[bin - (BINSIZE - new_NFOUR2 / 2)];
+            V_tmp[bin] = V2[bin - (BINSIZE - new_NFOUR2 / 2)];
         }
 
     }
 
     // do myconvlv and replace the diode response array
-    trigger->myconvlv( V_total_forconvlv, BINSIZE*2, detector->fdiode_real_double, V_total_forconvlv);
+    trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real_double, V_total_forconvlv);
 
     // do replace the part we get from noise + signal
-    for (int bin=signalbin1-BINSIZE/2+(trigger->maxt_diode_bin); bin<signalbin1+BINSIZE/2+BINSIZE; bin++) {
-        trigger->Full_window[ID][bin] = V_total_forconvlv[bin - signalbin1 + BINSIZE/2];
-        trigger->Full_window_V[ID][bin] += V_tmp[bin - signalbin1 + BINSIZE/2];
-        //
+    for (int bin = signalbin1 - new_NFOUR1 / 4 + (trigger->maxt_diode_bin); bin < signalbin2 + new_NFOUR2 / 4; bin++) {
+        trigger->Full_window[ID][bin] = V_total_forconvlv[bin - signalbin1 + new_NFOUR1 / 4];
+        trigger->Full_window_V[ID][bin] += V_tmp[bin - signalbin1 + new_NFOUR1 / 4];
+        
         // electronics saturation effect
         if ( trigger->Full_window_V[ID][bin] > settings1->V_SATURATION ) trigger->Full_window_V[ID][bin] = settings1->V_SATURATION;
         else if ( trigger->Full_window_V[ID][bin] < -1.*settings1->V_SATURATION ) trigger->Full_window_V[ID][bin] = -1.*settings1->V_SATURATION;
@@ -4038,25 +4036,22 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
 
 
 // this one is for three connected signals 
-void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin0, int signalbin1, int signalbin2, vector <double> &V0, vector <double> &V1, vector <double> &V2, int *noise_ID, int ID, int StationIndex) {
+void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin0, int signalbin1, int signalbin2, vector <double> &V0, vector <double> &V1, vector <double> &V2, int *noise_ID, int ID, int StationIndex, int new_NFOUR1, int new_NFOUR2, int new_NFOUR3) {
 
-    int BINSIZE = settings1->NFOUR/2;
-
-//    int BINSIZE = detector->stations[StationIndex].NFOUR/2;
     int bin_value;
     int signal_dbin = signalbin2 - signalbin1;
     int signal_dbin0 = signalbin1 - signalbin0;
-    //vector <double> V_total_forconvlv;   // total time domain waveform (noise + signal)
-    double V_tmp[BINSIZE*2];
-    for(int bin_tmp=0; bin_tmp<BINSIZE*2; bin_tmp++) {
+    int BINSIZE = new_NFOUR1 / 4 + signal_dbin + new_NFOUR2 / 4;
+    double V_tmp[BINSIZE];
+    for(int bin_tmp=0; bin_tmp<BINSIZE; bin_tmp++) {
         V_tmp[bin_tmp] = 0.;
     }
     
     V_total_forconvlv.clear();
     
     // first, fill the noise values
-    for (int bin=0; bin<BINSIZE*2; bin++) {
-        bin_value = signalbin1 - BINSIZE/2 + bin;
+    for (int bin = 0; bin < BINSIZE; bin++) {
+        bin_value = signalbin1 - new_NFOUR1 / 4 + bin;
 
         // save the noise waveform
         if ( settings1->NOISE_CHANNEL_MODE==0) {
@@ -4076,46 +4071,45 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
 
 
         // exchange from pure noise to noise + signal
-        if (bin < signal_dbin) {  // bins where no second signal is shown
-            if ( signal_dbin0 + bin < BINSIZE ) {   // previous signal is also here!
-                V_total_forconvlv[bin] = V_total_forconvlv[bin] + V1[bin] + V0[ signal_dbin0 + bin];
-                V_tmp[bin] = V1[bin] + V0[ signal_dbin0 + bin];
+        if (bin < (BINSIZE - new_NFOUR2 / 2)) {  // bins where no second signal is shown
+            if (bin < (signalbin0 + new_NFOUR0 / 4 - signalbin1)) {   // previous signal is also here!
+                V_total_forconvlv[bin] = V_total_forconvlv[bin] + V1[bin] + V0[bin + (new_NFOUR0 / 2 - (signalbin0 + new_NFOUR0 / 4 - signalbin1))];
+                V_tmp[bin] = V1[bin] + V0[bin + (new_NFOUR0 / 2 - (signalbin0 + new_NFOUR0 / 4 - signalbin1))];
             }
             else {  // no previous signal, and next signal
                 V_total_forconvlv[bin] = V_total_forconvlv[bin] + V1[bin];
                 V_tmp[bin] = V1[bin];
             }
         }
-        else if (bin < BINSIZE) { // bins where first + second signal is shown
+        else if (bin < new_NFOUR1 / 2) { // bins where first + second signal is shown
             if ( signal_dbin0 + bin < BINSIZE ) {   // previous signal is also here!
-                V_total_forconvlv[bin] = V_total_forconvlv[bin] + V1[bin] + V0[ signal_dbin0 + bin] + V2[bin - signal_dbin];
-                V_tmp[bin] = V1[bin] + V0[ signal_dbin0 + bin] + V2[bin - signal_dbin];
+                V_total_forconvlv[bin] = V_total_forconvlv[bin] + V1[bin] + V0[bin + (new_NFOUR0 / 2 - (signalbin0 + new_NFOUR0 / 4 - signalbin1))] + V2[bin - (BINSIZE - new_NFOUR2 / 2)];
+                V_tmp[bin] = V1[bin] + V0[bin + (new_NFOUR0 / 2 - (signalbin0 + new_NFOUR0 / 4 - signalbin1))] + V2[bin - (BINSIZE - new_NFOUR2 / 2)];
             }
             else {  // no previous signal, and next signal
-                V_total_forconvlv[bin] = V_total_forconvlv[bin] + V1[bin] + V2[bin - signal_dbin];
-                V_tmp[bin] = V1[bin] + V2[bin - signal_dbin];
+                V_total_forconvlv[bin] = V_total_forconvlv[bin] + V1[bin] + V2[bin - (BINSIZE - new_NFOUR2 / 2)];
+                V_tmp[bin] = V1[bin] + V2[bin - (BINSIZE - new_NFOUR2 / 2)];
             }
         }
-        else if (bin < BINSIZE + signal_dbin) { // bins where only second signal is shown
-            V_total_forconvlv[bin] = V_total_forconvlv[bin] + V2[bin - signal_dbin];
-            V_tmp[bin] = V2[bin - signal_dbin];
+        else { // bins where only second signal is shown
+            V_total_forconvlv[bin] = V_total_forconvlv[bin] + V2[bin - (BINSIZE - new_NFOUR2 / 2)];
+            V_tmp[bin] = V2[bin - (BINSIZE - new_NFOUR2 / 2)];
         }
 
     }
 
     // do myconvlv and replace the diode response array
-    trigger->myconvlv( V_total_forconvlv, BINSIZE*2, detector->fdiode_real_double, V_total_forconvlv);
+    trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real_double, V_total_forconvlv);
 
     // do replace the part we get from noise + signal
-    for (int bin=signalbin1-BINSIZE/2+(trigger->maxt_diode_bin); bin<signalbin1+BINSIZE/2+BINSIZE; bin++) {
-        trigger->Full_window[ID][bin] = V_total_forconvlv[bin - signalbin1 + BINSIZE/2];
-        trigger->Full_window_V[ID][bin] += V_tmp[bin - signalbin1 + BINSIZE/2];
-        //
+    for (int bin = signalbin1 - new_NFOUR1 / 4 + (trigger->maxt_diode_bin); bin < signalbin2 + new_NFOUR2 / 4; bin++) {
+        trigger->Full_window[ID][bin] = V_total_forconvlv[bin - signalbin1 + new_NFOUR1 / 4];
+        trigger->Full_window_V[ID][bin] += V_tmp[bin - signalbin1 + new_NFOUR1 / 4];
+
         // electronics saturation effect
         if ( trigger->Full_window_V[ID][bin] > settings1->V_SATURATION ) trigger->Full_window_V[ID][bin] = settings1->V_SATURATION;
         else if ( trigger->Full_window_V[ID][bin] < -1.*settings1->V_SATURATION ) trigger->Full_window_V[ID][bin] = -1.*settings1->V_SATURATION;
     }
-
 
     //V_total_forconvlv.clear();
 
@@ -4808,7 +4802,6 @@ void Report::GetNoisePhase(Settings *settings1) {
 
     noise_phase.clear();    // remove all previous noise_phase vector values
 
-    //for (int i=0; i<settings1->NFOUR/4; i++) {
     for (int i=0; i<settings1->DATA_BIN_SIZE/2; i++) {  // noise with DATA_BIN_SIZE bin array
         noise_phase.push_back(2*PI*gRandom->Rndm());  // get random phase for flat thermal noise
     }

--- a/Report.cc
+++ b/Report.cc
@@ -3620,9 +3620,9 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
     }
 
     //! do replace the part we get from noise + signal
-    for (int bin = signalbin1 - new_NFOUR1 / 4 + (trigger->maxt_diode_bin); bin < signalbin2 + new_NFOUR2 / 4; bin++) {
-        trigger->Full_window[ID][bin] = V_total_forconvlv[bin - signalbin1 + new_NFOUR1 / 4];
-        trigger->Full_window_V[ID][bin] += V_tmp[bin - signalbin1 + new_NFOUR1 / 4];
+    for (int bin = min_bin + (trigger->maxt_diode_bin); bin < max_bin; bin++) {
+        trigger->Full_window[ID][bin] = V_total_forconvlv[bin - min_bin];
+        trigger->Full_window_V[ID][bin] += V_tmp[bin - min_bin];
         
         // electronics saturation effect
         if ( trigger->Full_window_V[ID][bin] > settings1->V_SATURATION ) trigger->Full_window_V[ID][bin] = settings1->V_SATURATION;
@@ -3707,9 +3707,9 @@ void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, 
     }
 
     //! do replace the part we get from noise + signal
-    for (int bin = signalbin1 - new_NFOUR1 / 4 + (trigger->maxt_diode_bin); bin < signalbin2 + new_NFOUR2 / 4; bin++) {
-        trigger->Full_window[ID][bin] = V_total_forconvlv[bin - signalbin1 + new_NFOUR1 / 4];
-        trigger->Full_window_V[ID][bin] += V_tmp[bin - signalbin1 + new_NFOUR1 / 4];
+    for (int bin = min_bin + (trigger->maxt_diode_bin); bin < max_bin; bin++) {
+        trigger->Full_window[ID][bin] = V_total_forconvlv[bin - min_bin];
+        trigger->Full_window_V[ID][bin] += V_tmp[bin - min_bin];
 
         //! electronics saturation effect
         if ( trigger->Full_window_V[ID][bin] > settings1->V_SATURATION ) trigger->Full_window_V[ID][bin] = settings1->V_SATURATION;

--- a/Report.cc
+++ b/Report.cc
@@ -906,8 +906,9 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
 
                                                 /*! 
                                                     MK added -2023-05-20-
-                                                    change length of interpolate/cropped WF to slightly lonager than length of original time-domain signal
+                                                    changes the length of interpolated/cropped WF to slightly longer than length of original time-domain signal
                                                     this automatic changes will prevent the cliped WF no matter how signal is long
+                                                    user dont have to empirically adjust the NFOUR values
                                                 */
                                                 int new_NFOUR = settings1->NFOUR;
                                                 if (settings1->DYNAMIC_NFOUR == 1) {

--- a/Report.h
+++ b/Report.h
@@ -94,7 +94,7 @@ class Antenna_r {
         vector < vector <double> > Vfft;  // signal V preparing for FFT
         vector < vector <double> > Vfft_noise;  // noise V preparing for FFT
 
-        vector < vector <int> > New_NFOUR; ///< dynamic nfour length for each signal. MK added -2023-05-20-
+        vector <int> New_NFOUR; ///< dynamic nfour length for each signal. MK added -2023-05-20-
 
         // below time domain simulation output
         vector <double> time;   // time of time domain Askaryan radiation

--- a/Report.h
+++ b/Report.h
@@ -249,7 +249,8 @@ class Report {
     
     void ClearUselessfromConnect(Detector *detector, Settings *settings1, Trigger *trigger);
 
-    
+   
+        //! Signal + noise convolution functions for multiple connected signal cases. Now each function will accept each signal's NFOUR value and use them for convolution. MK updated -2023-05-23-
         void Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin, vector <double> &V, int *noise_ID, int ID, int StationIndex, int new_NFOUR1);   // literally get noise waveform from trigger class and add signal voltage "V" and do convlv. convlv result will replace the value in Full_window array
         
         void Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin_1, int signalbin_2, vector <double> &V1, vector <double> &V2, int *noise_ID, int ID, int StationIndex, int new_NFOUR1, int new_NFOUR2);   // literally get noise waveform from trigger class and add signal voltage "V" and do convlv. convlv result will replace the value in Full_window array

--- a/Report.h
+++ b/Report.h
@@ -98,9 +98,9 @@ class Antenna_r {
         // below time domain simulation output
         vector <double> time;   // time of time domain Askaryan radiation
         vector <double> time_mimic;   // time of time domain Askaryan radiation (same time range with data)
-        vector <double> V_mimic;    // signal + noise waveform which mimics the data (size : NFOUR/2 bin)
+        vector <double> V_mimic;    // signal + noise waveform which mimics the data (size : WAVEFORM_LENGTH bin)
 
-        int global_trig_bin; // from V_mimic [0, NFOUR/2] bins, where global trigger occured
+        int global_trig_bin; // from V_mimic [0, WAVEFORM_LENGTH/2] bins, where global trigger occured
 
         vector < vector <double> > Ax;     // vector potential x component
         vector < vector <double> > Ay;

--- a/Report.h
+++ b/Report.h
@@ -94,6 +94,7 @@ class Antenna_r {
         vector < vector <double> > Vfft;  // signal V preparing for FFT
         vector < vector <double> > Vfft_noise;  // noise V preparing for FFT
 
+        vector < vector <int> > New_NFOUR; ///< dynamic nfour length for each signal. MK added -2023-05-20-
 
         // below time domain simulation output
         vector <double> time;   // time of time domain Askaryan radiation
@@ -137,7 +138,7 @@ class Antenna_r {
         void clear ();  // clear all vector format information for next event
         void clear_useless ( Settings *settings1 );  // clear all vector information which are useless
 
-        ClassDef(Antenna_r,3);
+        ClassDef(Antenna_r,4);
 };
 
 class String_r {

--- a/Report.h
+++ b/Report.h
@@ -250,7 +250,7 @@ class Report {
     void ClearUselessfromConnect(Detector *detector, Settings *settings1, Trigger *trigger);
 
     
-        void Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin, vector <double> &V, int *noise_ID, int ID, int StationIndex, int new_NFOUR);   // literally get noise waveform from trigger class and add signal voltage "V" and do convlv. convlv result will replace the value in Full_window array
+        void Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin, vector <double> &V, int *noise_ID, int ID, int StationIndex, int new_NFOUR1);   // literally get noise waveform from trigger class and add signal voltage "V" and do convlv. convlv result will replace the value in Full_window array
         
         void Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin_1, int signalbin_2, vector <double> &V1, vector <double> &V2, int *noise_ID, int ID, int StationIndex, int new_NFOUR1, int new_NFOUR2);   // literally get noise waveform from trigger class and add signal voltage "V" and do convlv. convlv result will replace the value in Full_window array
 

--- a/Report.h
+++ b/Report.h
@@ -285,14 +285,12 @@ class Report {
 
         void ApplyFilter(int bin_n, Detector *detector, double &vmmhz);
         void ApplyFilter_databin(int bin_n, Detector *detector, double &vmmhz);
-        void ApplyFilter_NFOUR(int bin_n, Detector *detector, double &vmmhz);
         void ApplyFilter_OutZero (double freq, Detector *detector, double &vmmhz);
 
 
         // apply gain in Preamp
         void ApplyPreamp(int bin_n, Detector *detector, double &vmmhz);
         void ApplyPreamp_databin(int bin_n, Detector *detector, double &vmmhz);
-        void ApplyPreamp_NFOUR(int bin_n, Detector *detector, double &vmmhz);
         void ApplyPreamp_OutZero (double freq, Detector *detector, double &vmmhz);
 
 	void ApplyNoiseFig_databin(int ch, int bin_n, Detector *detector, double &vmmhz, Settings *settings1);
@@ -300,7 +298,6 @@ class Report {
         // apply gain in FOAM
         void ApplyFOAM(int bin_n, Detector *detector, double &vmmhz);
         void ApplyFOAM_databin(int bin_n, Detector *detector, double &vmmhz);
-        void ApplyFOAM_NFOUR(int bin_n, Detector *detector, double &vmmhz);
         void ApplyFOAM_OutZero (double freq, Detector *detector, double &vmmhz);
 
 

--- a/Report.h
+++ b/Report.h
@@ -250,11 +250,11 @@ class Report {
     void ClearUselessfromConnect(Detector *detector, Settings *settings1, Trigger *trigger);
 
     
-        void Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin, vector <double> &V, int *noise_ID, int ID, int StationIndex);   // literally get noise waveform from trigger class and add signal voltage "V" and do convlv. convlv result will replace the value in Full_window array
+        void Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin, vector <double> &V, int *noise_ID, int ID, int StationIndex, int new_NFOUR);   // literally get noise waveform from trigger class and add signal voltage "V" and do convlv. convlv result will replace the value in Full_window array
         
-        void Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin_1, int signalbin_2, vector <double> &V1, vector <double> &V2, int *noise_ID, int ID, int StationIndex);   // literally get noise waveform from trigger class and add signal voltage "V" and do convlv. convlv result will replace the value in Full_window array
+        void Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin_1, int signalbin_2, vector <double> &V1, vector <double> &V2, int *noise_ID, int ID, int StationIndex, int new_NFOUR1, int new_NFOUR2);   // literally get noise waveform from trigger class and add signal voltage "V" and do convlv. convlv result will replace the value in Full_window array
 
-        void Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin_0, int signalbin_1, int signalbin_2, vector <double> &V0, vector <double> &V1, vector <double> &V2, int *noise_ID, int ID, int StationIndex);   // literally get noise waveform from trigger class and add signal voltage "V" and do convlv. convlv result will replace the value in Full_window array
+        void Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin_0, int signalbin_1, int signalbin_2, vector <double> &V0, vector <double> &V1, vector <double> &V2, int *noise_ID, int ID, int StationIndex, int new_NFOUR0, int new_NFOUR1, int new_NFOUR2);   // literally get noise waveform from trigger class and add signal voltage "V" and do convlv. convlv result will replace the value in Full_window array
 
 
         void Apply_Gain_Offset(Settings *settings1, Trigger *trigger, Detector *detector, int ID, int StationIndex); // we need to apply a gain offset to the basic waveforms.
@@ -367,7 +367,7 @@ class Report {
         double init_T; // locate zero time at the middle and give random time shift (for interpolated waveforms)
 
 
-        ClassDef(Report,1);
+        ClassDef(Report,2);
 
 };
 

--- a/Settings.cc
+++ b/Settings.cc
@@ -112,7 +112,9 @@ outputdir="outputs"; // directory where outputs go
   PHASE=90.;            // default : 90 deg phase (it means all imaginary values)
 
   NFOUR=1024;           // default : 1024, same as in icemc
-    
+  
+  DYNAMIC_NFOUR=0;      // 0 : (default) follow pre/user-configured NFOUR value, 1: change NFOUR value by following signal length. MK added -2023-05-20-
+  
   NOISE=0;              // degault : 0, flat thermal noise, 1 : for TestBed (DETECTOR=3), use Rayleigh distribution fitted for borehole channels
 
   ATMOSPHERE=1;         // default : 1, include atmosphere
@@ -404,6 +406,9 @@ void Settings::ReadFile(string setupfile) {
               }
               else if (label == "NFOUR") {
                   NFOUR = atof( line.substr(line.find_first_of("=") + 1).c_str() );
+              }
+              else if (label == "DYNAMIC_NFOUR") {
+                  DYNAMIC_NFOUR = atof( line.substr(line.find_first_of("=") + 1).c_str() );
               }
               else if (label == "NOISE") {
                   NOISE = atof( line.substr(line.find_first_of("=") + 1).c_str() );

--- a/Settings.h
+++ b/Settings.h
@@ -90,6 +90,8 @@ class Settings
 
         int NFOUR;              // number of total bins for FFT. has to be power of 2 values
 
+        int DYNAMIC_NFOUR;      // 0 : (default) follow pre/user-configured NFOUR value, 1: change NFOUR value by following signal length. MK added -2023-05-20-
+
         int NOISE;              // noise condition settings degault 0 ( : thermal flat noise), 1 : Rayleigh dist. fit for installed TestBed geom, 2: Noise figure values for station 2 (??) from Thomas Meures 2015/2016
 
         int ATMOSPHERE;         // include atmosphere 1, no 0
@@ -437,7 +439,7 @@ int horizontal_banana_points;
  // end of values from icemc
 
 
-  ClassDef(Settings,1);
+  ClassDef(Settings,2);
 
 
 };

--- a/Trigger.cc
+++ b/Trigger.cc
@@ -726,21 +726,9 @@ void Trigger::myconvlv(vector <double> &data,const int DATA_BIN_SIZE,vector <dou
     
     
     const int length=DATA_BIN_SIZE;
-//    double data_copy[length];
-    //double fdiode_real[length];
 
     // we are going to make double sized array for complete convolution
     double power_noise_copy[length*2];
-
-/*    
-    for (int i=0;i<NFOUR/2;i++) {
-	data_copy[i]=data[i];
-    }
-    for (int i=NFOUR/2;i<length;i++) {
-	data_copy[i]=0.;
-    }
-*/  
-
 
     // fill half of the array as power (actually energy) and another half (actually extanded part) with zero padding (Numerical Recipes 643 page)
     for (int i=0;i<length;i++) {
@@ -827,20 +815,9 @@ void Trigger::myconvlv(double *data,const int DATA_BIN_SIZE,vector <double> &fdi
     
     
     const int length=DATA_BIN_SIZE;
-//    double data_copy[length];
-    //double fdiode_real[length];
 
     // we are going to make double sized array for complete convolution
     double power_noise_copy[length*2];
-
-/*    
-    for (int i=0;i<NFOUR/2;i++) {
-	data_copy[i]=data[i];
-    }
-    for (int i=NFOUR/2;i<length;i++) {
-	data_copy[i]=0.;
-    }
-*/  
 
 
     // fill half of the array as power (actually energy) and another half (actually extanded part) with zero padding (Numerical Recipes 643 page)
@@ -933,18 +910,7 @@ void Trigger::myconvlv_half(vector <double> &data,const int NFOUR,vector <double
     
     
     const int length=NFOUR;
-//    double data_copy[length];
-    //double fdiode_real[length];
     double power_noise_copy[length];
-
-/*    
-    for (int i=0;i<NFOUR/2;i++) {
-	data_copy[i]=data[i];
-    }
-    for (int i=NFOUR/2;i<length;i++) {
-	data_copy[i]=0.;
-    }
-*/  
 
 
     for (int i=0;i<length;i++) {
@@ -1022,19 +988,8 @@ void Trigger::myconvlv_half(double *data,const int NFOUR,vector <double> &fdiode
     
     
     const int length=NFOUR;
-//    double data_copy[length];
-    //double fdiode_real[length];
     double power_noise_copy[length];
   
-/*    
-    for (int i=0;i<NFOUR/2;i++) {
-	data_copy[i]=data[i];
-    }
-    for (int i=NFOUR/2;i<length;i++) {
-	data_copy[i]=0.;
-    }
-*/  
-
 
     for (int i=0;i<length;i++) {
 	power_noise_copy[i]=(data[i]*data[i])/Zr*TIMESTEP;

--- a/Trigger.cc
+++ b/Trigger.cc
@@ -97,7 +97,6 @@ void Trigger::Reset_V_noise_freqbin(Settings *settings1, Detector *detector) {
     else if (settings1->NOISE_CHANNEL_MODE == 1) {
     
         for (int ch=0; ch<detector->params.number_of_antennas; ch++) {
-            //V_noise_freqbin_ch.push_back( sqrt( (double)(settings1->DATA_BIN_SIZE) * 50. * KBOLTZ * settings1->NOISE_TEMP / (settings1->TIMESTEP * 2.) ) );
             V_noise_freqbin_ch.push_back( sqrt( (double)(settings1->DATA_BIN_SIZE) * 50. * KBOLTZ * detector->GetTemp(0, ch, settings1) / (settings1->TIMESTEP * 2.) ) );
         }
     }

--- a/Trigger.h
+++ b/Trigger.h
@@ -86,23 +86,11 @@ class Trigger {
      int CheckChannelsPass( vector <double> &V_total_diode);
      
      
-     void myconvlv(vector <double> &data, const int NFOUR, vector <double> &fdiode, vector <double> &diodeconv);
+     void myconvlv(vector <double> &data, const int DATA_BIN_SIZE, vector <double> &fdiode, vector <double> &diodeconv);
 
-     void myconvlv(double *data, const int NFOUR, vector <double> &fdiode, vector <double> &diodeconv);
+     void myconvlv(double *data, const int DATA_BIN_SIZE, vector <double> &fdiode, vector <double> &diodeconv);
 
-     
-
-     void myconvlv_half(vector <double> &data, const int NFOUR, vector <double> &fdiode, vector <double> &diodeconv);
-
-     void myconvlv_half(double *data, const int NFOUR, vector <double> &fdiode, vector <double> &diodeconv);
-
-
-
-           //double Full_window[16][16384];  // test with array, not vector
-           //vector < vector <double> >  Full_window;  // test with array, not vector
-
-     
-     ClassDef(Trigger,1);
+     ClassDef(Trigger,2);
 
 };
 

--- a/Trigger.h
+++ b/Trigger.h
@@ -83,8 +83,6 @@ class Trigger {
 
      void GetNewNoiseWaveforms(Settings *settings1, Detector *detector, Report *report);
 
-     int CheckChannelsPass( vector <double> &V_total_diode);
-     
      
      void myconvlv(vector <double> &data, const int DATA_BIN_SIZE, vector <double> &fdiode, vector <double> &diodeconv);
 


### PR DESCRIPTION
Dear reviewers, This PR is not just including update, but also has a lots of code cleaning. It can be overwhelming (possibly frustrating) to check all of them. I try to explain most of them in this document but I realized document itself also become long. I will be really appreciate, if you spare little bit of patient for this PR (and for me). Thank you!:) 

### 1. Dynamic NFOUR option.

After we generate an E-field WF and apply a detector response, we interpolate the signal with pre/user-defined time width (`TIMESTEP`) and zero-pad the signal by also pre/user-defined pad length (`NFOUR`). Then, we moved on to the noise generation part and convolved them together. 

If the signal strength is enormous or the distance to the antenna cluster is too close, unfortunately, the pad length is too small to contain the entire signal. And signal WF from the root output has an unnatural or clipped shape. We traditionally set the pad length (`NFOUR`) to be large (1024 to 2048) based on experience, but I found, It can still cause the clipped WF.

In this update, I added the `DYNAMIC_NFOUR` option in the Setting class. If the `DYNAMIC_NFOUR` is set to `1`, the pad length will be automatically adjusted based on the original signal WF length. And prevent clipped WF. I must tell you this `DYNAMIC_NFOUR` option is only implemented in the time-domain mode (`SIMULATION_MODE = 1`). If user select the `DYNAMIC_NFOUR` mode without selecting time-domain mode, It will automatically use default NFOUR value.

`DYNAMIC_NFOUR` option is [placed](https://github.com/ara-software/AraSim/blob/3aa1d09724761d4e7118aa5a4795e166bf30c717/Report.cc#L916) just after sim apply detector response.
```
/*! 
    MK added -2023-05-20-
    If user selected DYNAMIC_NFOUR to 1,
    Changes the length of zero-pad (NFOUR / 2) to have a same length with original time-domain signal
    These automatic changes will prevent the cliped WF issue no matter how signal is long
    User don't have to empirically adjust the NFOUR values
*/
int new_NFOUR = settings1->NFOUR; ///< Default is user/pre-configured NFOUR
int new_init_T = init_T;
if (settings1->DYNAMIC_NFOUR == 1) {
    new_NFOUR = pad_len; ///< same with original signal WF
    if (new_NFOUR < settings1->NFOUR) new_NFOUR = settings1->NFOUR; ///< if length of signal is smaller than default NFOUR, just use default NFOUR
    new_init_T = settings1->TIMESTEP * -1.e9 * ((double) new_NFOUR / 4 + RandomTshift); ///< recalculate initial time
    //! We save the longest/smallest NFOUR for placing signal into noise pad at later.
    //! Use maximum NFOUR will prevent entire signal to be placed outside of noise pad
    //! Use minimum NFOUR will allow trigger scan to start the scan from the begining of all the signals in the noise pad
    if (new_NFOUR < new_NFOUR_min) new_NFOUR_min = new_NFOUR; 
    if (new_NFOUR > new_NFOUR_max) new_NFOUR_max = new_NFOUR;
}
//! Filled interpolated signal WF into zero-pad
double new_volts_forint[new_NFOUR / 2];
double new_T_forint[new_NFOUR / 2];
for(int n = 0; n < new_NFOUR / 2; n++){
    new_T_forint[n] = new_init_T + (double)n * settings1->TIMESTEP * 1.e9;
}
stations[i].strings[j].antennas[k].New_NFOUR[ray_sol_cnt] = new_NFOUR; ///< save in Report branch

//! do linear interpolation
//! changed to sinc interpolation Dec 2020 by BAC
Tools::SincInterpolation(pad_len, T_forfft, V_forfft, new_NFOUR / 2, new_T_forint, new_volts_forint);
```
`new_NFOUR` will set new zero-pad for signal WF (`new_volts_forint`, `new_T_forint`), and the interpolationed WF from sine interpolation will be stored in the zero-pad array
Different NFOUR values set by each signal WF will be saved in Report branch.

While setting NFOUR, we save the longest/smallest NFOUR for placing signal into noise pad at later.
We use maximum NFOUR (`new_NFOUR_max`) to prevent entire signal from being placed outside of the noise pad
And We use minimum NFOUR (`new_NFOUR_min`) to allow the trigger scan to start the scan from the beginning of all the signals in the noise pad

The maximum NFOUR (`new_NFOUR_max`) will be used to set [max_total_bin](https://github.com/ara-software/AraSim/blob/3aa1d09724761d4e7118aa5a4795e166bf30c717/Report.cc#L1668) to contain the longest signal in noise pad
```
//! calculate total number of bins we need to do trigger check
//! set the max_total_bin length by using new_NFOUR_max value to contain the longest signal in noise pad. MK added -2023-05-23-
max_total_bin = (stations[i].max_arrival_time - stations[i].min_arrival_time) / settings1->TIMESTEP + new_NFOUR_max * 3 + trigger->maxt_diode_bin;    // make more time
```

The minimum NFOUR (`new_NFOUR_min`) will be used to allow [trigger scan](https://github.com/ara-software/AraSim/blob/3aa1d09724761d4e7118aa5a4795e166bf30c717/Report.cc#L2115) to start the scan from the beginning of all the signals in the noise pad
```
//! Use new_NFOUR_min will allow trigger scan to start the scan from the begining of all the signals in the noise pad. MK added -2023-05-23-
trig_search_init = trigger->maxt_diode_bin + new_NFOUR_min;  // give some time shift for mimicing force trig events
trig_i = trig_search_init;

// save trig search bin info default (if no global trig, this value saved)
stations[i].total_trig_search_bin = max_total_bin - trig_search_init;
```

Because of different signal pad length for each solution, whether two ray solutions are connected or not will be identify by sum of half length of each pad
```
//! signal_dbin should be smaller than sum of half length of each signal WF to have connceted signals
int new_NFOUR_d = stations[i].strings[j].antennas[k].New_NFOUR[m - 1] / 4 + stations[i].strings[j].antennas[k].New_NFOUR[m] / 4;
if (signal_dbin[m - 1] < new_NFOUR_d)
{
    // if two ray_sol time delay is smaller than time window
    connect_signals.push_back(1);
    // cout<<"need two signal connection!!"<<endl;
}
```

The signal + noise convolution part (`Select_Wave_Convlv_Exchange()` [1st func.](https://github.com/ara-software/AraSim/blob/3aa1d09724761d4e7118aa5a4795e166bf30c717/Report.cc#L3517) [2nd func](https://github.com/ara-software/AraSim/blob/3aa1d09724761d4e7118aa5a4795e166bf30c717/Report.cc#L3569), [3rd func](https://github.com/ara-software/AraSim/blob/3aa1d09724761d4e7118aa5a4795e166bf30c717/Report.cc#L3651)) is modified to accept the different NFOUR values. 
Since each signal WF length is different, we need to set the length of convolution pad by checking all the input signals length. We also need to consider the case that one of the signal range can cover other signals range. So, setting convolution pad like below is necessary.
```
void Report::Select_Wave_Convlv_Exchange(Settings *settings1, Trigger *trigger, Detector *detector, int signalbin1, int signalbin2, vector <double> &V1, vector <double> &V2, int *noise_ID, int ID, int StationIndex, int new_NFOUR1, int new_NFOUR2) {

    int bin_value;
    //! MK added -2023-05-23-
    //! set the edge of convolution pad by checking all the input signals length
    //! We do this in case second signal is covering entire first signal or vise versa
    int min_bin1 = signalbin1 - new_NFOUR1 / 4; ///< 1st signal
    int min_bin2 = signalbin2 - new_NFOUR2 / 4; ///< 2nd signal
    int min_bin = min_bin1;
    if (min_bin1 > min_bin2) min_bin = min_bin2; ///< if 2nd signal edge is smaller than 1st signal, we use 2nd signal edge for pad edge
    int max_bin1 = signalbin1 + new_NFOUR1 / 4;
    int max_bin2 = signalbin2 + new_NFOUR2 / 4;
    int max_bin = max_bin2;
    if (max_bin1 > max_bin2) max_bin = max_bin1; ///< if 1st signal edge is bigger than 2nd signal, we use 1st signal edge for pad edge
    int BINSIZE = max_bin - min_bin + 1;
    if (BINSIZE > int(settings1->NFOUR / 2) && BINSIZE <= settings1->NFOUR) BINSIZE = settings1->NFOUR; ///< Let just use double length. It is easier to apply diode
    double V_tmp[BINSIZE];
    for(int bin_tmp=0; bin_tmp<BINSIZE; bin_tmp++) {
        V_tmp[bin_tmp] = 0.;
    }
```

At last, because of the possibility of dynamic convolution pad length, I decided to create [new function](https://github.com/ara-software/AraSim/blob/3aa1d09724761d4e7118aa5a4795e166bf30c717/Detector.cc#L5075) in Detector class that re-padding diode values based on convolution pad length. If convolution pad is not the same as default NFOUR value, It will re-pad the diode value and transform to frequency spectrum. And the [convolution functions](https://github.com/ara-software/AraSim/blob/3aa1d09724761d4e7118aa5a4795e166bf30c717/Report.cc#LL3629C5-L3636C6) will use that array.
```
//! do myconvlv and replace the diode response array
//! Since signal WF length can be different by DYNAMIC_NFOUR option, based on the signal WF length we use different length of f-domain diode array. MK added -2023-05-23-
if (BINSIZE == int(settings1->NFOUR / 2)) trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real, V_total_forconvlv); ///< use default diode
else if (BINSIZE == settings1->NFOUR) trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real_double, V_total_forconvlv); ///< use default double length diode
else { ///< signal length is different than any default diode, we repad the diode and use it
        detector->get_NewDynamicDiodeModel(BINSIZE); ///< repad diode value
        trigger->myconvlv( V_total_forconvlv, BINSIZE, detector->fdiode_real_dynamic_databin, V_total_forconvlv);
    }
```

### 2. clean up
I clean up the Detector, Trigger, and Report classes. Unfortunately, it was a bit hard to implement the Dynamic NFOUR without cleaning.


**In the AraSim class**, I delete two [array](https://github.com/ara-software/AraSim/blob/4292256cef8e674cab0e8289f2739f347f441ea4/AraSim.cc#L290). They are taking space and do nothing.
```
double x_V[settings1->NFOUR/2];
double y_V[settings1->NFOUR/2];
```


**In the Detector class**, I mainly removed arrays that have names, including `NFOUR`. 
It is not used anymore, but somehow sim still generates the value, saves it in the below [arrays](https://github.com/ara-software/AraSim/blob/4292256cef8e674cab0e8289f2739f347f441ea4/Detector.h#L239), and does nothing. 
Removed arrays in the header file
```
vector <double> FilterGain_NFOUR;
vector <double> PreampGain_NFOUR;
vector <double> FOAMGain_NFOUR;
double GetFilterGain_NFOUR(int bin) { return FilterGain_NFOUR[bin]; }
double GetPreampGain_NFOUR(int bin) { return PreampGain_NFOUR[bin]; }
double GetFOAMGain_NFOUR(int bin) { return FOAMGain_NFOUR[bin]; }
```
I also removed some script lines that related to the above lines. Below [lines](https://github.com/ara-software/AraSim/blob/4292256cef8e674cab0e8289f2739f347f441ea4/Detector.cc#L3359) are example
```
    // for NFOUR/2 t domain array
    double xfreq_NFOUR[settings1->NFOUR/4+1];   // array for FFT freq bin
    double ygain_NFOUR[settings1->NFOUR/4+1];   // array for gain in FFT bin

    df_fft = 1./ ( (double)(settings1->NFOUR/2) * settings1->TIMESTEP );

    for (int i=0;i<settings1->NFOUR/4+1;i++) {    // this one is for DATA_BIN_SIZE
        xfreq_NFOUR[i] = (double)i * df_fft / (1.E6); // from Hz to MHz
    }

    Tools::SimpleLinearInterpolation( N, xfreq, ygain, settings1->NFOUR/4+1, xfreq_NFOUR, ygain_NFOUR );

    for (int i=0;i<settings1->NFOUR/4+1;i++) {
        FilterGain_NFOUR.push_back( ygain_NFOUR[i] );
    }
```
I also added one more array and function in the detector class. When we start the simulation, we generate a diode response based on the `NOUR `length. In this update, I propose a dynamic `NOUR `option, in which NFOUR length will be changed by signal length (especially 1st and 2nd connected signal). So, when we convolved the noise and signal, we needed to re-pad the diode too. Below function will take the diode response from the sim and will re-pad when the signal length is different than NFOUR length.
Array in the header file
`vector <double> fdiode_real_dynamic_databin;`
Function
```
//! repadding diode value based on input pad length
void Detector::get_NewDynamicDiodeModel(int pad_len) {

    double diode_real_fft[pad_len * 2]; ///< double sized array for myconvlv

    for (int i = 0; i < pad_len * 2; i++) {  // 512 bin added for zero padding
        if ( i < (int)(maxt_diode / TIMESTEP) ) {
            diode_real_fft[i] = diode_real[i];
        } else {
            diode_real_fft[i] = 0.;
        }
    }

    // forward FFT
    Tools::realft(diode_real_fft, 1, pad_len * 2);

    // clear previous data as we need new diode response array for new pad_len
    fdiode_real_dynamic_databin.clear(); 

    // save f domain diode response in fdiode_real_dynamic_databin
    for (int i = 0; i < pad_len * 2; i++) {
        fdiode_real_dynamic_databin.push_back( diode_real_fft[i] );
    }
}
```


**In the Setting class**, I added the option that control dynamic NFOUR option
Array in the header file
` int DYNAMIC_NFOUR; `
in the `.cc` file
```
DYNAMIC_NFOUR=0;      // 0 : (default) follow pre/user-configured NFOUR value, 1: change NFOUR value by 
following signal length. MK added -2023-05-20-
...
              else if (label == "DYNAMIC_NFOUR") {
                  DYNAMIC_NFOUR = atof( line.substr(line.find_first_of("=") + 1).c_str() );
              }

```


**In the Trigger class**, I removed several uncommented lines and the `myconvlv_half()`  and `CheckChannelsPass()` functions. It looks like we are not using it. But let me know if it has purposes.
In the header file, I removed [below](https://github.com/ara-software/AraSim/blob/4292256cef8e674cab0e8289f2739f347f441ea4/Trigger.h#L86) arrays
```
int CheckChannelsPass( vector <double> &V_total_diode);
void myconvlv(vector <double> &data, const int NFOUR, vector <double> &fdiode, vector <double> &diodeconv);
void myconvlv(double *data, const int NFOUR, vector <double> &fdiode, vector <double> &diodeconv);
void myconvlv_half(vector <double> &data, const int NFOUR, vector <double> &fdiode, vector <double> &diodeconv);
void myconvlv_half(double *data, const int NFOUR, vector <double> &fdiode, vector <double> &diodeconv);
```
in the `.cc` file, I removed  `myconvlv_half()`  and `CheckChannelsPass()` functions and [not used array](https://github.com/ara-software/AraSim/blob/4292256cef8e674cab0e8289f2739f347f441ea4/Trigger.cc#L57)
```
iminbin = NFOUR/4 - detector->ibinshift + detector->idelaybeforepeak;
imaxbin = NFOUR/4 - detector->ibinshift + detector->idelaybeforepeak + detector->window;
```
two [myconvlv_half()](https://github.com/ara-software/AraSim/blob/4292256cef8e674cab0e8289f2739f347f441ea4/Trigger.cc#L932) functions
```
// test for myconvlv with NFOUR/2 version
void Trigger::myconvlv_half(vector <double> &data,const int NFOUR,vector <double> &fdiode, vector <double> &diodeconv) {
    const int length=NFOUR;
//    double data_copy[length];
    //double fdiode_real[length];
    double power_noise_copy[length];
/*    
    for (int i=0;i<NFOUR/2;i++) {
	data_copy[i]=data[i];
    }
    for (int i=NFOUR/2;i<length;i++) {
	data_copy[i]=0.;
    }
*/  
    for (int i=0;i<length;i++) {
	power_noise_copy[i]=(data[i]*data[i])/Zr*TIMESTEP;
    }
    Tools::realft(power_noise_copy,1,length);
    double ans_copy[length];
    // change the sign (from numerical recipes 648, 649 page)
    for (int j=1;j<length/2;j++) {
	ans_copy[2*j]=(power_noise_copy[2*j]*fdiode[2*j]-power_noise_copy[2*j+1]*fdiode[2*j+1])/((double)length/2);
	//ans_copy[2*j]=(power_noise_copy[2*j]*fdiode[2*j]+power_noise_copy[2*j+1]*fdiode[2*j+1])/((double)length/2);
	ans_copy[2*j+1]=(power_noise_copy[2*j+1]*fdiode[2*j]+power_noise_copy[2*j]*fdiode[2*j+1])/((double)length/2);
	//ans_copy[2*j+1]=(power_noise_copy[2*j+1]*fdiode[2*j]-power_noise_copy[2*j]*fdiode[2*j+1])/((double)length/2);
    }
    ans_copy[0]=power_noise_copy[0]*fdiode[0]/((double)length/2);
    ans_copy[1]=power_noise_copy[1]*fdiode[1]/((double)length/2);
    Tools::realft(ans_copy,-1,length);
    diodeconv.clear();  // remove previous values in diodeconv
    for (int i=0;i<length;i++) {
	//power_noise[i]=power_noise_copy[i];
	//diodeconv[i]=ans_copy[i];
	diodeconv.push_back( ans_copy[i] );
    }
    int iminsamp,imaxsamp; // find min and max samples such that
    // the diode response is fully overlapping with the noise waveform
    iminsamp=(int)(maxt_diode/TIMESTEP);
    // the noise waveform is NFOUR/2 long
    // then for a time maxt_diode/TIMESTEP at the end of that, the
    // diode response function is only partially overlappying with the
    // waveform in the convolution
    imaxsamp=NFOUR/2;
    //  cout << "iminsamp, imaxsamp are " << iminsamp << " " << imaxsamp << "\n";
    if (imaxsamp<iminsamp) {
	cout << "Noise waveform is not long enough for this diode response.\n";
	exit(1);
    }
    //int ibin=((iminsamp+imaxsamp)-(iminsamp+imaxsamp)%2)/2;
    //cout << "ibin is " << ibin << "\n";
    // return the 50th sample, right in the middle
   // onediodeconvl=diodeconv[ibin];
    //mindiodeconvl=0.;
    //for (int i=iminsamp;i<imaxsamp;i++) {
//	if (diodeconv[i]<mindiodeconvl)
//	    mindiodeconvl=diodeconv[i];
  //  }
}
```
[CheckChannelsPass()](https://github.com/ara-software/AraSim/blob/4292256cef8e674cab0e8289f2739f347f441ea4/Trigger.cc#L1111) function
```
int Trigger::CheckChannelsPass( vector <double> &V_total_diode ) {

    int ch_pass_bin = 0;

    //for (int ibin=iminbin; ibin<imaxbin; ibin++) {
    for (int ibin=(int)(maxt_diode/TIMESTEP);ibin<DATA_BIN_SIZE;ibin++) {

        if ( V_total_diode[ibin] < powerthreshold * rmsdiode ) {
            ch_pass_bin = ibin;
            ibin = DATA_BIN_SIZE;   // stop loop
        }

	    cout << "Noise waveform is not long enough for this diode response.\n";
	    exit(1);
    }

    return ch_pass_bin; // if there was any iwindow values pass the threshold, return = bin number where passed the trigger, if nothing, return = 0;
}
```

**In the Report class**, It looks like a lot. But I just removed all... unnecessary repetitive lines. Unfortunately, lots of identical lines are written in the code because It simply has different `if` conditions. And definitely, It can be shortened to a few lines. I only cleaned (removed repetitive lines) the time-domain signal generation part, triggering part, and readout window setting part
In the header file, I removed [functions](https://github.com/ara-software/AraSim/blob/4292256cef8e674cab0e8289f2739f347f441ea4/Report.h#LL288C14-L288C31) that loading not-used arrays in the detector class.
```
void ApplyFilter_NFOUR(int bin_n, Detector *detector, double &vmmhz);
void ApplyPreamp_NFOUR(int bin_n, Detector *detector, double &vmmhz);
void ApplyFOAM_NFOUR(int bin_n, Detector *detector, double &vmmhz);
```
And I added  `vector <int> New_NFOUR;` array for storing dynamic NFOUR values
in the .cc file,
First, I cleaned the [signal generation part in time-domain mode](https://github.com/ara-software/AraSim/blob/4292256cef8e674cab0e8289f2739f347f441ea4/Report.cc#L762) (`SIMULATION_MODE == 1`)
Mainly, I just cleaned the comment and reorganized the codes.
```
if (settings1->USE_ARA_ICEATTENU == 1 || settings1->USE_ARA_ICEATTENU == 0)
{
atten_factor = 1. / ray_output[0][ray_sol_cnt] *IceAttenFactor *mag * fresnel;  // assume whichray = 0, now vmmhz1m_tmp has all factors except for the detector properties (antenna gain, etc)
 }
 else if (settings1->USE_ARA_ICEATTENU == 2)
{
atten_factor = 1. / ray_output[0][ray_sol_cnt] *mag * fresnel;  //apply freq dependent IceAttenFactor later
 }
```
is changed to below
```
double ice_atten_factor = IceAttenFactor ; ///< assume whichray = 0, now vmmhz1m_tmp has all factors except for the detector properties (antenna gain, etc)
if (settings1->USE_ARA_ICEATTENU == 2) ice_atten_factor = 1.; //apply freq dependent IceAttenFactor later
 atten_factor = 1. / ray_output[0][ray_sol_cnt] *ice_atten_factor *mag * fresnel;
```

```
// now new NFOUR for zero padding

 // now we have to make NFOUR/2 number of bins with random init time
//
// as a test, make first as it is and zero pad

double V_forfft[stations[i].strings[j].antennas[k].Nnew[ray_sol_cnt]];
double T_forfft[stations[i].strings[j].antennas[k].Nnew[ray_sol_cnt]];

for (int n = 0; n < stations[i].strings[j].antennas[k].Nnew[ray_sol_cnt]; n++)
 {
// make Tarray, Earray located at the center of Nnew array

T_forfft[n] = Tarray[outbin / 2] - (dT_forfft *(double)(stations[i].strings[j].antennas[k].Nnew[ray_sol_cnt] / 2 - n));
if ((n >= stations[i].strings[j].antennas[k].Nnew[ray_sol_cnt] / 2 - outbin / 2) &&
(n < stations[i].strings[j].antennas[k].Nnew[ray_sol_cnt] / 2 + outbin / 2))
 {
V_forfft[n] = Earray[n - (stations[i].strings[j].antennas[k].Nnew[ray_sol_cnt] / 2 - outbin / 2)];
 }
 else
V_forfft[n] = 0.;
```
is changed to below
```
//! second, let's make zero pad what has Nnew length and fill with E-field
int pad_len = stations[i].strings[j].antennas[k].Nnew[ray_sol_cnt];
double V_forfft[pad_len]; ///< E-field value
 double T_forfft[pad_len]; ///< time in ns
double time_offset = Tarray[outbin / 2] - dT_forfft * (double)(pad_len / 2); ///< time offset between E-field center and zero-pad center
int front_pad_len = pad_len / 2 - outbin / 2; ///< length of eampty space in front
int back_pad_len = pad_len / 2 + outbin / 2; ///< length of eampty space in back
for (int n = 0; n < pad_len; n++) {
 //! make Tarray, Earray located at the center of Nnew array
T_forfft[n] = time_offset + (double)n * dT_forfft;
if ((n >= front_pad_len) && (n < back_pad_len)) V_forfft[n] = Earray[n - front_pad_len]; ///< fill with E-field value
else V_forfft[n] = 0.; ///< fill with zero
 }
```

[All the effective height (Heff) lines](https://github.com/ara-software/AraSim/blob/4292256cef8e674cab0e8289f2739f347f441ea4/Report.cc#L854) are simply changed below. I organized values that can be changed by the if condition at the front
```
int ant_number = 0; 
if (settings1->ANTENNA_MODE == 1) ant_number = k; ///< There are dfferences in Top and Bottom VPol. if ant_number is 2, GetGain_1D_OutZero() will apply Top VPol gain 
int ant_type = detector->stations[i].strings[j].antennas[k].type; ///< 0: VPol, 1: HPol
if (settings1->ALL_ANT_V_ON == 1) ant_type = 0; ///< all the antennas are VPol

//! effective height for last frequency bin 
freq_lastbin = dF_Nnew *((double)pad_len / 2. + 0.5); ///< in Hz 0.5 to place the middle of the bin and avoid zero freq
heff_lastbin = GaintoHeight(detector->GetGain_1D_OutZero(freq_lastbin *1.E-6,   // to MHz
                                                                antenna_theta, antenna_phi, ant_type, ant_number),
                                                                freq_lastbin, icemodel->GetN(detector->stations[i].strings[j].antennas[k]));

```
```
//! loop over all frequency bin and apply detector response
 for (int n = 0; n < pad_len / 2; n++) {
//! calculate antenna effective height
    heff = GaintoHeight(detector->GetGain_1D_OutZero(freq_tmp *1.E-6,   // to MHz
                                    antenna_theta, antenna_phi, ant_type, ant_number),
                                    freq_tmp, icemodel->GetN(detector->stations[i].strings[j].antennas[k]));
                                    stations[i].strings[j].antennas[k].Heff[ray_sol_cnt].push_back(heff); ///< save in Report branch
```

[The long trigger scan part](https://github.com/ara-software/AraSim/blob/4292256cef8e674cab0e8289f2739f347f441ea4/Report.cc#L2176) is changed to [below](https://github.com/ara-software/AraSim/blob/661cb663206d66b1c2961d6f728911304b9ca211/Report.cc#L2126). I organized values that can be changed by the if condition at the front. So there is no more repeated part. Trust me this is better than before.
```
                          while (trig_j < ch_ID) {
  
                              int string_i = detector->getStringfromArbAntID(i, trig_j);
                              int antenna_i = detector->getAntennafromArbAntID(i, trig_j);
  
                              //! set channel number for GetThres() and GetThresOffset() at here
                              //! we only use different channle number, if we only want to use VPol for trigger
                              int channel_num = detector->GetChannelfromStringAntenna(i, string_i, antenna_i, settings1);
                              if ((settings1->TRIG_ONLY_LOW_CH_ON == 1) && (settings1->DETECTOR != 3)) channel_num = GetChannelNum8_LowAnt(string_i, antenna_i); ///< reset channel numbers so that bottom antennas have ch 1-8
  
                              //! set threshold value at here
                              //! threshold value can be different hased on NOISE_CHANNEL_MODE and TRIG_ONLY_BH_ON options
                              double Thres_val = detector->GetThres(i, channel_num - 1, settings1) * detector->GetThresOffset(i, channel_num - 1, settings1);
                              if (settings1->NOISE_CHANNEL_MODE == 0) {Thres_val *= trigger->rmsdiode;}
                              else if (settings1->NOISE_CHANNEL_MODE == 1) {Thres_val *= trigger->rmsdiode_ch[channel_num - 1];}
                              else if (settings1->NOISE_CHANNEL_MODE == 2) {
                                  if ((settings1->TRIG_ONLY_BH_ON == 1) && (settings1->DETECTOR == 3)) {Thres_val *= trigger->rmsdiode_ch[channel_num - 1];}
                                  else { 
                                      if (channel_num - 1 < 8) {Thres_val *= trigger->rmsdiode_ch[channel_num - 1];}
                                      else {Thres_val *= trigger->rmsdiode_ch[8];}
                                  }                                
                              }
    
                              //! determine when we launch the trigger search at here 
                              //! if trig_start is true, we do trigger search
                              bool trig_start = false;
                              //! check if we want to use BH chs only for trigger analysis
                              if ((settings1->TRIG_ONLY_BH_ON == 1) && (settings1->DETECTOR == 3)) {
                                  //! trig by BH is only for TestBed case
                                  //! check if this channel is BH ch (DAQchan)
                                  if (detector->stations[i].strings[string_i].antennas[antenna_i].DAQchan == 0) {
                                      trig_start = true;
                                  }
                              }
                              //! in this case just use first 8 chs' thres values
                              else if ((settings1->TRIG_ONLY_LOW_CH_ON == 1) && (settings1->DETECTOR != 3)) {
                                  //! non-TestBed case, and only trig by lower 8 channels
                                  if (antenna_i < 2) {
                                      //! only antenna 0, 1 which are bottom 2 antennas
                                      //! set channel_num as new value (antenna 0, 1 are only possible antennas for channel_num 1 - 8)
                                      trig_start = true;
                                  }
                              }
                              //! other cases, use all possible chs for trigger analysis
                              else {
                                  trig_start = true;
                              }
  
                              //! launch trigger scan
                              if (trig_start == true) {
                                  // cout<<"trig_bin : "<<trig_bin<<endl;
                                  trig_bin = 0;
                                  // cout<<"trig_bin : "<<trig_bin<<endl;
                                  int ant_type = detector->stations[i].strings[string_i].antennas[antenna_i].type;
                                  while (trig_bin < trig_window_bin) {
                                      //! with threshold offset by chs
                                      if (trigger->Full_window[trig_j][trig_i + trig_bin] < Thres_val) {
                                          //! if this channel passed the trigger!
                                          // cout<<"trigger passed at bin "<<trig_i+trig_bin<<" ch : "<<trig_j<<endl;
                                          stations[i].strings[string_i].antennas[antenna_i].Trig_Pass = trig_i + trig_bin;
                                          N_pass++;
                                          if (ant_type == 0) N_pass_V++; // Vpol
                                          if (ant_type == 1) N_pass_H++; // Hpol
                                          if (last_trig_bin < trig_i + trig_bin) last_trig_bin = trig_i + trig_bin;   ///< added for fixed V_mimic
                                          trig_bin = trig_window_bin; ///< if confirmed this channel passed the trigger, no need to do rest of bins
                                          Passed_chs.push_back(trig_j);
                                      }
                                      trig_bin++;
                                  }
                              }
                              //! check all triggered channels not just 3
                              trig_j++;   ///< if station not passed the trigger, just go to next channel
                          }   ///< while trig_j < ch_ID
```

Lastly I also reorganized readout window part (V_mimic). I organized values that can be changed by the if condition at the front.
[terminal msg part](https://github.com/ara-software/AraSim/blob/4292256cef8e674cab0e8289f2739f347f441ea4/Report.cc#L2573) is changed to [below](https://github.com/ara-software/AraSim/blob/661cb663206d66b1c2961d6f728911304b9ca211/Report.cc#L2233)
```
//! set msg for triggered event at here
int ant_types = detector->stations[i].strings[string_i].antennas[antenna_i].type;
double posnu_d = event->Nu_Interaction[0].posnu.Distance(detector->stations[i].strings[string_i].antennas[antenna_i]);
 int noise_id = stations[i].strings[string_i].antennas[antenna_i].noise_ID[0];
int likely_sol = stations[i].strings[string_i].antennas[antenna_i].Likely_Sol;
//! skip this passed ch as it already has bin info
if (settings1->TRIG_ONLY_LOW_CH_ON == 0) {
    cout << endl << "trigger passed at bin " << trig_pass << "  passed ch : " << ch_loop << " (" << ant_types << "type) Direct dist btw posnu : " << posnu_d << " noiseID : " << noise_id;
} else if (settings1->TRIG_ONLY_LOW_CH_ON == 1) {
    cout << endl << "trigger passed at bin " << trig_pass << "  passed ant: str[" << string_i << "].ant[" << antenna_i << "] (" << ant_types << "type) Direct dist btw posnu : " << posnu_d << " noiseID : " << noise_id;
}
if (likely_sol != -1) {
    cout << " ViewAngle : " << stations[i].strings[string_i].antennas[antenna_i].view_ang[0] *DEGRAD << " LikelyTrigSignal : " << likely_sol;
}
```
[V_mimic part](https://github.com/ara-software/AraSim/blob/4292256cef8e674cab0e8289f2739f347f441ea4/Report.cc#L2597) is changed to [below](https://github.com/ara-software/AraSim/blob/661cb663206d66b1c2961d6f728911304b9ca211/Report.cc#L2255)
```
//! now save the voltage waveform to V_mimic
                                //! set initial time bin index and delay bins length at here
                                int time_bin_i = waveformCenter - waveformLength / 2; ///< center minus half length. yeah, this is initial time
                                int testbed_ch_delay = detector->params.TestBed_Ch_delay_bin[ch_loop] - detector->params.TestBed_BH_Mean_delay_bin; ///< testbed delay
                                int manual_delay_bins = detector->stations[i].strings[string_i].antennas[antenna_i].manual_delay_bin; ///< manual delay by user
                                
                                //! new DAQ waveform writing mechanism test
                                //! loop over readout window bin
                                for (int mimicbin = 0; mimicbin < waveformLength; mimicbin++) {

                                    int time_bin = time_bin_i + mimicbin;
                                    int wf_bin = last_trig_bin + time_bin;
                                    if (V_mimic_mode == 1 || V_mimic_mode == 2) { ///< add delay bin
                                        wf_bin -= testbed_ch_delay;
                                        time_bin -= testbed_ch_delay;
                                    }
                                    if (V_mimic_mode == 2) { ///< add manual delay bin
                                        wf_bin -= manual_delay_bins;
                                        time_bin -= manual_delay_bins;
                                    }
                                    double time_mimic_val = (double)time_bin * settings1->TIMESTEP * 1.e9; ///< set time at here by multiplying time width
                                    if (V_mimic_mode == 2) time_mimic_val += detector->params.TestBed_WFtime_offset_ns; ///< add offset time

                                    stations[i].strings[string_i].antennas[antenna_i].V_mimic.push_back(trigger->Full_window_V[ch_loop][wf_bin] * 1.e3);   // save in mV
                                    stations[i].strings[string_i].antennas[antenna_i].time.push_back(wf_bin);
                                    stations[i].strings[string_i].antennas[antenna_i].time_mimic.push_back(time_mimic_val);    // save in ns

                                    if (mimicbin == 0) {
                                        for (int m = 0; m < stations[i].strings[string_i].antennas[antenna_i].ray_sol_cnt; m++) { ///< calculates time of center of each rays signal based on readout window time config
                                            //! time offset between beginning of readout window and center of signal
                                            double signal_center_offset = (double)(stations[i].strings[string_i].antennas[antenna_i].SignalBin[m] - wf_bin) * settings1->TIMESTEP * 1.e9;
                                            //! time of center of signal based on readout window time config
                                            double signal_center_time = signal_center_offset + time_mimic_val;
                                            stations[i].strings[string_i].antennas[antenna_i].SignalBinTime.push_back(signal_center_time);
                                        }
                                    }
                                }

                                //! set global_trig_bin values
                                //! Global passed bin is the center of the window
                                int global_trig_bins = -1 * time_bin_i; ///< if (V_mimic_mode == 0) Global passed bin is the center of the window
                                if (V_mimic_mode == 1 || V_mimic_mode == 2) global_trig_bins += testbed_ch_delay; ///< Global passed bin is the center of the window + delay to each chs from araGeom
                                if (V_mimic_mode == 2) global_trig_bins += manual_delay_bins; ///< Global passed bin is the center of the window + delay to each chs from araGeom + fitted by eye
                                stations[i].strings[string_i].antennas[antenna_i].global_trig_bin = global_trig_bins;
                            }

```

Please let me know if you have a comment!
