### PR TITLE
Added missing include statement in Report header.

### DIFF
--- a/Report.h
+++ b/Report.h
@@ -9,6 +9,8 @@
 #include <vector>
 #include "TGraph.h"
 
+#include "Position.h"
+
 #ifndef __CINT__
 //Include output format to enable reading by analysis software AraRoot
 #ifdef ARA_UTIL_EXISTS


### PR DESCRIPTION
`Report` class uses structures from `Position` class but for some reason the include statement for `Position.h` is missing. This causes compilation errors for users if they `#include "Report.h"` without also including `#include "Position.h"`. 

I asked whether there was a reason for this missing include statement on #software-arasim on Slack, but no one had an explanation (or opposition to fixing this).