### PR TITLE
Pulser sims

### DIFF
--- a/Detector.cc
+++ b/Detector.cc
@@ -77,7 +77,7 @@ Detector::Detector(Settings * settings1, IceModel * icesurface, string setupfile
     params.number_of_antennas = 0;
 
     //initialize few params values.
-    params.freq_step = 60;
+    params.freq_step = 60;  //The hard-coding of this seems unnecessary, as it limits forces us to have our gain files go beyond 1000 MHz in data, which is out of band for us. - JCF 2/22/2024
     params.ang_step = 2664;
     params.freq_width = 16.667;
     params.freq_init = 83.333;
@@ -92,6 +92,10 @@ Detector::Detector(Settings * settings1, IceModel * icesurface, string setupfile
         params.freq_width = 5; //16.667;
         params.freq_init = 15; //83.333;
         params.DeployedStations = 4;
+    }
+    
+    if (settings1->ANTENNA_MODE == 5 or settings1->ANTENNA_MODE == 6) {
+        params.freq_step = 56; //This is a stop-gap measure to allow the Kansas models ot work in AraSim, which only have data up to 1000 MHz rather than 1066.66 MHz. - JCF 2/22/2024
     }
 
     //copy freq_width, freq_init in params to Detector freq_width, freq_init

--- a/Settings.h
+++ b/Settings.h
@@ -311,6 +311,7 @@ class Settings
                        // 3: use the chiba xfdtd models (treats top and bottom as the same)
                        // 4: use the chiba in-situ models (treats top and bottom as the same)
                        // 5: use the Kansas lab measurements that treat top and bottom vpol separately.
+                       // 6: Uses custom antenna models that the user can specify with the custom files in data/antennas/realizedGain
                        // The related wiki page for antenna models description:http://ara.icecube.wisc.edu/wiki/index.php/Antenna_model
                        
    //Impedances of RX and TX antennas.  All use the numbering scheme below:


### PR DESCRIPTION
Simulations in ANTENNA_MODE=5 (Kansas models) were leading to a seg fault.  This is because the Kansas gain files only have data up to 1000 MHz, while past data files went up to 1066.66 MHz.  This difference in structure conflicted with the variable params.freq_step, which was hard-coded to match the length of the old gain files that measured up to 1066.66 MHz.  I've added a stopgap measure to allow the Kansas models to work, but we should make params.freq_step dynamic to the input file rather than hard-coding it.