### PR TITLE
Updated antenna gain file read-in

### DIFF
--- a/Detector.cc
+++ b/Detector.cc
@@ -2287,16 +2287,38 @@ inline void Detector::ReadVgain(string filename, Settings *settings1) {
         while (NecOut.good() ) {
             for (int i=0; i<freq_step; i++) {
                 getline (NecOut, line);
-                if ( line.substr(0, line.find_first_of(":")) == "freq ") {
-                    Freq[i] = atof( line.substr(6, line.find_first_of("M")).c_str() );
-                    getline (NecOut, line); //read SWR
-                    double swr = atof(line.substr(5,11).c_str());
+                stringstream ss(line);
+                string buff;
+                vector<string> words;
+                while(ss >> buff)
+                  words.push_back(buff);
+                if (words.size() > 0 && words[0] == "freq") {
+                    if(words.size() != 4 || words[3] != "MHz")
+                      throw runtime_error("V antenna gain file frequency not properly formatted!");
+                    Freq[i] = stof( words[2] );
+                    // read SWR info
+                    getline (NecOut, line);
+                    words.clear();
+                    ss.clear();
+                    ss.str(line);
+                    while(ss >> buff)
+                      words.push_back(buff);
+                    if(words.size() != 3 || words[0] != "SWR")
+                      throw runtime_error("V antenna gain file SWR not properly formatted!");
+                    double swr = stof(words[2]);
                     Transm[i] = SWRtoTransCoeff(swr);
-                    getline (NecOut, line); //read names
+                    getline (NecOut, line); //read names (ie column names)
                     for (int j=0; j<ang_step; j++) {
                         getline (NecOut, line); //read data line
-                        Vgain[i][j] = pow(10, atof( line.substr( 7, 17 ).c_str() )/10);  //Importing gain in dB, then converting to linear gain
-                        Vphase[i][j] = atof( line.substr( 34 ).c_str() );  
+                        words.clear();
+                        ss.clear();
+                        ss.str(line);
+                        while(ss >> buff)
+                          words.push_back(buff);
+                        if(words.size() != 5)
+                          throw runtime_error("V antenna gain file data line not properly formatted!");
+                        Vgain[i][j] = pow(10, stof( words[2] )/10);  //Importing gain in dB, then converting to linear gain
+                        Vphase[i][j] = stof( words[4] );
                     }// end ang_step
                 }// end check freq label
             }// end freq_step
@@ -2334,16 +2356,38 @@ inline void Detector::ReadVgainTop(string filename, Settings *settings1) {
         while (NecOut.good() ) {
             for (int i=0; i<freq_step; i++) {
                 getline (NecOut, line);
-                if ( line.substr(0, line.find_first_of(":")) == "freq ") {
-                    Freq[i] = atof( line.substr(6, line.find_first_of("M")).c_str() );
-                    getline (NecOut, line); //read SWR
-                    double swr = atof(line.substr(5,11).c_str());
+                stringstream ss(line);
+                string buff;
+                vector<string> words;
+                while(ss >> buff)
+                  words.push_back(buff);
+                if (words.size() > 0 && words[0] == "freq") {
+                    if(words.size() != 4 || words[3] != "MHz")
+                      throw runtime_error("VTop antenna gain file frequency not properly formatted!");
+                    Freq[i] = stof( words[2] );
+                    // read SWR info
+                    getline (NecOut, line);
+                    words.clear();
+                    ss.clear();
+                    ss.str(line);
+                    while(ss >> buff)
+                      words.push_back(buff);
+                    if(words.size() != 3 || words[0] != "SWR")
+                      throw runtime_error("VTop antenna gain file SWR not properly formatted!");
+                    double swr = stof(words[2]);
                     Transm[i] = SWRtoTransCoeff(swr);
-                    getline (NecOut, line); //read names
+                    getline (NecOut, line); //read names (ie column names)
                     for (int j=0; j<ang_step; j++) {
                         getline (NecOut, line); //read data line
-                        VgainTop[i][j] = pow(10, atof( line.substr( 7, 17 ).c_str() )/10);  //Importing gain in dB, then converting to linear gain
-                        VphaseTop[i][j] = atof( line.substr( 34 ).c_str() ); 
+                        words.clear();
+                        ss.clear();
+                        ss.str(line);
+                        while(ss >> buff)
+                          words.push_back(buff);
+                        if(words.size() != 5)
+                          throw runtime_error("VTop antenna gain file data line not properly formatted!");
+                        VgainTop[i][j] = pow(10, stof( words[2] )/10);  //Importing gain in dB, then converting to linear gain
+                        VphaseTop[i][j] = stof( words[4] );  
                     }// end ang_step
                 }// end check freq label
             }// end freq_step
@@ -2385,16 +2429,38 @@ inline void Detector::ReadHgain(string filename, Settings *settings1) {
         while (NecOut.good() ) {
             for (int i=0; i<freq_step; i++) {
                 getline (NecOut, line);
-                if ( line.substr(0, line.find_first_of(":")) == "freq ") {
-                    Freq[i] = atof( line.substr(6, line.find_first_of("M")).c_str() );
-                    getline (NecOut, line); //read SWR
-                    double swr = atof(line.substr(5,11).c_str());
+                stringstream ss(line);
+                string buff;
+                vector<string> words;
+                while(ss >> buff)
+                  words.push_back(buff);
+                if (words.size() > 0 && words[0] == "freq") {
+                    if(words.size() != 4 || words[3] != "MHz")
+                      throw runtime_error("H antenna gain file frequency not properly formatted!");
+                    Freq[i] = stof( words[2] );
+                    // read SWR info
+                    getline (NecOut, line);
+                    words.clear();
+                    ss.clear();
+                    ss.str(line);
+                    while(ss >> buff)
+                      words.push_back(buff);
+                    if(words.size() != 3 || words[0] != "SWR")
+                      throw runtime_error("H antenna gain file SWR not properly formatted!");
+                    double swr = stof(words[2]);
                     Transm[i] = SWRtoTransCoeff(swr);
-                    getline (NecOut, line); //read names
+                    getline (NecOut, line); //read names (ie column names)
                     for (int j=0; j<ang_step; j++) {
                         getline (NecOut, line); //read data line
-                        Hgain[i][j] = pow(10, atof( line.substr( 7, 17 ).c_str() )/10);  //Importing gain in dB, then converting to linear gain                       
-                        Hphase[i][j] = atof( line.substr( 34 ).c_str() );  // read gain (not dB)
+                        words.clear();
+                        ss.clear();
+                        ss.str(line);
+                        while(ss >> buff)
+                          words.push_back(buff);
+                        if(words.size() != 5)
+                          throw runtime_error("H antenna gain file data line not properly formatted!");
+                        Hgain[i][j] = pow(10, stof( words[2] )/10);  //Importing gain in dB, then converting to linear gain
+                        Hphase[i][j] = stof( words[4] );  
                     }// end ang_step
                 }// end check freq label
             }// end freq_step
@@ -2431,16 +2497,38 @@ inline void Detector::ReadTxgain(string filename, Settings *settings1) {
         while (NecOut.good() ) {
             for (int i=0; i<freq_step; i++) {
                 getline (NecOut, line);
-                if ( line.substr(0, line.find_first_of(":")) == "freq ") {
-                    Freq[i] = atof( line.substr(6, line.find_first_of("M")).c_str() );
-                    getline (NecOut, line); //read SWR
-                    double swr = atof(line.substr(5,11).c_str());
+                stringstream ss(line);
+                string buff;
+                vector<string> words;
+                while(ss >> buff)
+                  words.push_back(buff);
+                if (words.size() > 0 && words[0] == "freq") {
+                    if(words.size() != 4 || words[3] != "MHz")
+                      throw runtime_error("Tx antenna gain file frequency not properly formatted!");
+                    Freq[i] = stof( words[2] );
+                    // read SWR info
+                    getline (NecOut, line);
+                    words.clear();
+                    ss.clear();
+                    ss.str(line);
+                    while(ss >> buff) 
+                      words.push_back(buff);
+                    if(words.size() != 3 || words[0] != "SWR")
+                      throw runtime_error("Tx antenna gain file SWR not properly formatted!");
+                    double swr = stof(words[2]);
                     Transm[i] = SWRtoTransCoeff(swr);
-                    getline (NecOut, line); //read names
+                    getline (NecOut, line); //read names (ie column names)
                     for (int j=0; j<ang_step; j++) {
                         getline (NecOut, line); //read data line
-                        Txgain[i][j] = pow(10, atof( line.substr( 7, 17 ).c_str() )/10);  //Importing gain in dB, then converting to linear gain
-                        Txphase[i][j] = atof( line.substr( 34 ).c_str() );  
+                        words.clear();
+                        ss.clear();
+                        ss.str(line);
+                        while(ss >> buff)
+                          words.push_back(buff);
+                        if(words.size() != 5)
+                          throw runtime_error("Tx antenna gain file data line not properly formatted!");
+                        Txgain[i][j] = pow(10, stof( words[2] )/10);  //Importing gain in dB, then converting to linear gain
+                        Txphase[i][j] = stof( words[4] );  
                     }// end ang_step
                 }// end check freq label
             }// end freq_step

--- a/Detector.h
+++ b/Detector.h
@@ -212,6 +212,13 @@ class IdealStation{
 	ClassDef(IdealStation, 1);
 	
 };
+
+enum EAntennaType {
+  eVPol, // (bottom) Vpol
+  eVPolTop, // top Vpol
+  eHPol, // Hpol
+  eTx // transmitter 
+};
   
 class Detector {
     private:
@@ -219,10 +226,7 @@ class Detector {
         static const int ang_step_max = 2664;
         void ReadAllAntennaGains(Settings *settings1);
         double SWRtoTransCoeff(double swr);
-        void ReadVgain(string filename, Settings *settings1);
-        void ReadVgainTop(string filename, Settings *settings1);
-    	void ReadHgain(string filename, Settings *settings1);
-    	void ReadTxgain(string filename, Settings *settings1);    
+        void ReadAntennaGain(string filename, Settings *settings1, EAntennaType type);
         double Vgain[freq_step_max][ang_step_max];
         double Vphase[freq_step_max][ang_step_max];
         double VgainTop[freq_step_max][ang_step_max];
@@ -274,13 +278,13 @@ class Detector {
 
         void ReadElectChain(string filename, Settings *settings1);
         int gain_ch; // Number of channels used for gain model array population in ReadElectChain()
-	std::vector< std::vector <double> > ElectGain; //Elect chain gain (unitless) for Detector freq bin array
-	std::vector< std::vector <double> > ElectPhase; // Elect chain phase (rad) for Detector freq bin array 
+        std::vector< std::vector <double> > ElectGain; //Elect chain gain (unitless) for Detector freq bin array
+        std::vector< std::vector <double> > ElectPhase; // Elect chain phase (rad) for Detector freq bin array 
 
-	void ReadTrig_Delays_Masking(string filename, Settings *settings1);
-	std::vector<double> triggerDelay; //trigger delay for a given channel (seconds?)
-	std::vector<int> triggerMask;  //trigger masking decision value (either 0 or 1)
-	std::vector<int> activeDelay;  //decision value to activate delay (either 0 or 1)
+        void ReadTrig_Delays_Masking(string filename, Settings *settings1);
+        std::vector<double> triggerDelay; //trigger delay for a given channel (seconds?)
+        std::vector<int> triggerMask;  //trigger masking decision value (either 0 or 1)
+        std::vector<int> activeDelay;  //decision value to activate delay (either 0 or 1)
 
         void ReadGainOffset_TestBed(string filename, Settings *settings1);
         vector <double> GainOffset_TB_ch;   // constant gain offset for the TestBed chs 
@@ -326,14 +330,14 @@ class Detector {
         void ReadRayleighFit_DeepStation(string filename, Settings *settings1);
 
 
-	void ReadNoiseFigure(string filename, Settings *settings1); 
-	double NoiseFig_ch[16][freq_step_max];
-	vector < vector < double > > NoiseFig_databin_ch;
+        void ReadNoiseFigure(string filename, Settings *settings1); 
+        double NoiseFig_ch[16][freq_step_max];
+        vector < vector < double > > NoiseFig_databin_ch;
 
 
-	vector <double> transV_databin;
-	vector <double> transVTop_databin;
-	vector <double> transH_databin;
+        vector <double> transV_databin;
+        vector <double> transVTop_databin;
+        vector <double> transH_databin;
 
 
         void FlattoEarth_ARA(IceModel *icesurface);
@@ -358,7 +362,7 @@ class Detector {
         vector <ARA_station> stations;
         vector <Antenna_string> strings;
 
-	int NoiseFig_numCh;
+        int NoiseFig_numCh;
 
         vector <double> freq_forfft;
 
@@ -397,7 +401,7 @@ class Detector {
         double GetFOAMGain_1D_OutZero(double freq);
 
 	
-	double GetElectGain(int bin, int gain_ch_no) { return ElectGain[gain_ch_no][bin]; }   // same bin with Vgain, Hgain
+        double GetElectGain(int bin, int gain_ch_no) { return ElectGain[gain_ch_no][bin]; }   // same bin with Vgain, Hgain
         double GetElectGain_1D_OutZero(double freq, int gain_ch_no);
         double GetElectPhase_1D(double freq, int gain_ch_no);
 

--- a/log.txt
+++ b/log.txt
@@ -1901,3 +1901,9 @@ Updated a few aspects to our antenna modeling:
 Updating the antenna effective height calculation.  Calculation was double-counting two factors: a factor of 1/2 that corrected an issue with a previous definition of the effective height, and a factor of 1/sqrt(2) that accounted for a 3 dB splitter in the electronics chain.  That 3 dB splitter only applied to A1-3, whereas A4-5 followed a different setup.  This split in power is now folded into the electronics gain step via the new function Report::ApplySplitterFactor(), which figures out the appropriate power reduction based on the station being simulated.
 
 ==============================================================================
+
+2024/3/21 Marco Muzio
+
+Removed ReadVgain, ReadVgainTop, ReadHgain, and ReadTxgain functions and replaced them with a single read-in function: ReadAntennaGain. This read-in function is identical to the others but removes the redundancy, improves the read-in's robustness to varying whitespace to separate values, and does some basic checks for errors so they aren't silent. Also added enum to specify these antenna types.
+
+==============================================================================


### PR DESCRIPTION
Updated antenna gain file read-in to be robust to various numbers of spaces/tabs, so long as the delimiter is whitespace, and to do some basic error checking. Also unified all antenna gain file read-in into a single function and added enums to encode antenna type.