### PR TITLE
Added calculation of launch angles of the RF trajectory from the source vertex.

### DIFF
--- a/Report.cc
+++ b/Report.cc
@@ -4939,7 +4939,8 @@ void Report::GetAngleLaunch(Vector &launch_vector, double &launch_theta, double 
     /*
     2024-07-01 JCF
     Takes the launch vector of the signal and calculates the theta and phi of the launch vector in the 
-    receiveing antenna's coordinate system.
+    station-centric coordinates and returns them in degrees; where theta=0 is along the upward vertical axis,
+    theta=90 is along the horizon, and theta=180 is along the downward vertical axis.
     
     This is necessary because for source reconstruction, we need the launch vector of the RF signal in 
     conjunction with the polarization to find the neutrino trajectory.

--- a/Report.cc
+++ b/Report.cc
@@ -443,7 +443,7 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
     double phi_rec;
     double theta_rec;
 
-    double freq_tmp, heff, antenna_theta, antenna_phi;  // values needed for apply antenna gain factor and prepare fft, trigger
+    double freq_tmp, heff, antenna_theta, antenna_phi, launch_theta, launch_phi;  // values needed for apply antenna gain factor and prepare fft, trigger
     double heff_Tx, Tx_theta, Tx_phi, heff_Tx_lastbin; // Values for transmitting antenna mode.
     double volts_forfft[settings1->NFOUR / 2];  // array for fft
     double dT_forfft;
@@ -672,6 +672,7 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
 
                                 // get the arrival angle at the antenna, and store the relevant polarization factors
                                 GetAngleAnt(receive_vector, detector->stations[i].strings[j].antennas[k], antenna_theta, antenna_phi);  // get theta, phi for signal ray arrived at antenna
+                                GetAngleLaunch(launch_vector, launch_theta, launch_phi);
 
                                 Vector thetaHat = Vector(cos(antenna_theta *(PI / 180)) *cos(antenna_phi *(PI / 180)),
                                     cos(antenna_theta *(PI / 180)) *sin(antenna_phi *(PI / 180)),
@@ -684,6 +685,8 @@ void Report::Connect_Interaction_Detector_V2(Event *event, Detector *detector, R
                                 stations[i].strings[j].antennas[k].Pol_factorV.push_back(abs(thetaHat *Pol_vector));
                                 stations[i].strings[j].antennas[k].phi_rec.push_back(antenna_phi *(PI / 180));
                                 stations[i].strings[j].antennas[k].theta_rec.push_back(antenna_theta *(PI / 180));
+                                stations[i].strings[j].antennas[k].phi_launch.push_back(launch_phi *(PI / 180));
+                                stations[i].strings[j].antennas[k].theta_launch.push_back(launch_theta *(PI / 180));                                
 
                                 // old freq domain signal mode (AVZ model)
                                 if (settings1->SIMULATION_MODE == 0)
@@ -3197,6 +3200,13 @@ void Report::rerun_event(Event *event, Detector *detector,
                         detector->stations[0].strings[j].antennas[k],
                         antenna_theta, antenna_phi
                         );
+                        
+                    // get launch angle of signal
+                    double launch_theta, launch_phi;
+                    GetAngleLaunch(
+                        launch_vector, 
+                        launch_theta, launch_phi
+                        );                        
                     
                     // this is the 1/R and fresnel and focusing effect
                     double atten_factor = 1. / ray_output[0][ray_sol_cnt] * mag * fresnel;
@@ -4921,6 +4931,22 @@ void Report::GetAngleAnt(Vector &rec_vector, Position &antenna, double &ant_thet
     Vector flip_receive_vector = -1. * rec_vector;
     ant_theta = flip_receive_vector.Theta() * TMath::RadToDeg(); // return in degrees
     ant_phi = flip_receive_vector.Phi() * TMath::RadToDeg();
+
+}
+
+void Report::GetAngleLaunch(Vector &launch_vector, double &launch_theta, double &launch_phi) {
+    
+    /*
+    2024-07-01 JCF
+    Takes the launch vector of the signal and calculates the theta and phi of the launch vector in the 
+    receiveing antenna's coordinate system.
+    
+    This is necessary because for source reconstruction, we need the launch vector of the RF signal in 
+    conjunction with the polarization to find the neutrino trajectory.
+    */
+    
+    launch_theta = launch_vector.Theta() * TMath::RadToDeg();
+    launch_phi = launch_vector.Phi() * TMath::RadToDeg();
 
 }
 

--- a/Report.h
+++ b/Report.h
@@ -61,6 +61,8 @@ class Antenna_r {
         vector <double> rec_ang;     //receiving angle phi (in radians)
         vector <double> phi_rec;     // receiving phi angle,in antenna's coord system.
         vector <double> theta_rec;     // receiving theta angle, in antenna's coord system.
+        vector <double> phi_launch;     // launch phi angle,in antenna's coord system.
+        vector <double> theta_launch;     // launch theta angle, in antenna's coord system.    
         vector <double> reflect_ang; // surface reflection angle (if 100 : no reflection case)
         vector <double> Dist;        //Distance between posnu and antenna
         vector <double> L_att;        //Attenuation factor
@@ -358,6 +360,7 @@ class Report {
 
 
         void GetAngleAnt(Vector &rec_vector, Position &antenna, double &ant_theta, double &ant_phi);
+        void GetAngleLaunch(Vector &launch_vector, double &launch_theta, double &launch_phi);
 
         void GetNoiseWaveforms(Settings *settings1, Detector *detector, double vhz_noise, double *vnoise);
         void GetNoiseWaveforms_ch(Settings *settings1, Detector *detector, double vhz_noise, double *vnoise, int ch);


### PR DESCRIPTION
Implemented calculation and storage of launch angles of the RF signal from the source vertex to work in conjunction with [AraRoot Pull #68](https://github.com/ara-software/AraRoot/pull/68).  This stores the MCTruth values of the theta and phi launch angles in the Report pointer alongside the MCTruth values of the receiving angles of the signal.  The calculation of the launch angles follows the same framework as the receiving angles, which is a simple conversion of the Cartesian vector into theta and phi.