### PR TITLE
Adding DETECTOR_YEAR parameter to Settings class that gets called when initializing a Detector class.

### DIFF
--- a/Detector.cc
+++ b/Detector.cc
@@ -6854,7 +6854,7 @@ void Detector::ImportStationInfo(Settings *settings1, int StationIndex, int Stat
         //GetSSAfromChannel(stationNum, chan, &antennaNum, &stringNum);
         GetSSAfromChannel(StationID, chan, &antennaNum, &stringNum, settings1);
 
-        if (araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].polType != AraAntPol::kSurface){
+        if (araGeom->getStationInfo(StationID_AraRoot, settings1->DETECTOR_YEAR)->fAntInfo[antId].polType != AraAntPol::kSurface){
 
             stations[StationIndex].strings[stringNum].antennas[antennaNum].SetX(stations[StationIndex].GetX()+araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].antLocation[0]);
             stations[StationIndex].strings[stringNum].antennas[antennaNum].SetY(stations[StationIndex].GetY()+araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].antLocation[1]);

--- a/Detector.cc
+++ b/Detector.cc
@@ -669,10 +669,10 @@ Detector::Detector(Settings * settings1, IceModel * icesurface, string setupfile
                         //int chan = GetChannelfromStringAntenna (i+1,j,k);
                         int chan = GetChannelfromStringAntenna(i + 1, j, k, settings1);
 
-                        stations[i].strings[j].antennas[k].SetX(stations[i].GetX() + araGeom -> getStationInfo(i + 1) -> fAntInfo[chan - 1].antLocation[0]);
-                        stations[i].strings[j].antennas[k].SetY(stations[i].GetY() + araGeom -> getStationInfo(i + 1) -> fAntInfo[chan - 1].antLocation[1]);
+                        stations[i].strings[j].antennas[k].SetX(stations[i].GetX() + araGeom -> getStationInfo(i + 1, settings1->DETECTOR_YEAR) -> fAntInfo[chan - 1].antLocation[0]);
+                        stations[i].strings[j].antennas[k].SetY(stations[i].GetY() + araGeom -> getStationInfo(i + 1, settings1->DETECTOR_YEAR) -> fAntInfo[chan - 1].antLocation[1]);
                         //stations[i].strings[j].antennas[k].SetZ(araGeom->fStationInfo[i+1].fAntInfo[chan-1].antLocation[2]-double(settings1->DEPTH_CHANGE));
-                        stations[i].strings[j].antennas[k].SetZ(araGeom -> getStationInfo(i + 1) -> fAntInfo[chan - 1].antLocation[2]);
+                        stations[i].strings[j].antennas[k].SetZ(araGeom -> getStationInfo(i + 1, settings1->DETECTOR_YEAR) -> fAntInfo[chan - 1].antLocation[2]);
                         cout <<
                             "DetectorStation:string:antenna:X:Y:Z:: " <<
                             i << " : " <<
@@ -691,8 +691,8 @@ Detector::Detector(Settings * settings1, IceModel * icesurface, string setupfile
                     //int chanstring = GetChannelfromStringAntenna (i+1, j,2);
                     int chanstring = GetChannelfromStringAntenna(i + 1, j, 2, settings1);
 
-                    stations[i].strings[j].SetX(stations[i].GetX() + araGeom -> getStationInfo(i + 1) -> fAntInfo[chanstring - 1].antLocation[0]);
-                    stations[i].strings[j].SetY(stations[i].GetY() + araGeom -> getStationInfo(i + 1) -> fAntInfo[chanstring - 1].antLocation[1]);
+                    stations[i].strings[j].SetX(stations[i].GetX() + araGeom -> getStationInfo(i + 1, settings1->DETECTOR_YEAR) -> fAntInfo[chanstring - 1].antLocation[0]);
+                    stations[i].strings[j].SetY(stations[i].GetY() + araGeom -> getStationInfo(i + 1, settings1->DETECTOR_YEAR) -> fAntInfo[chanstring - 1].antLocation[1]);
 
                 }
 
@@ -6704,12 +6704,12 @@ void Detector::UseAntennaInfo(int stationNum, Settings *settings1){
         //GetSSAfromChannel(stationNum, chan, &antennaNum, &stringNum);
         GetSSAfromChannel(stationNum, chan, &antennaNum, &stringNum, settings1);
 	
-        if (araGeom->getStationInfo(stationNum)->fAntInfo[chan-1].polType != AraAntPol::kSurface){
+        if (araGeom->getStationInfo(stationNum, settings1->DETECTOR_YEAR)->fAntInfo[chan-1].polType != AraAntPol::kSurface){
 
-            stations[stationNum].strings[stringNum].antennas[antennaNum].SetX(stations[stationNum].GetX()+araGeom->getStationInfo(stationNum)->fAntInfo[chan-1].antLocation[0]);
-            stations[stationNum].strings[stringNum].antennas[antennaNum].SetY(stations[stationNum].GetY()+araGeom->getStationInfo(stationNum)->fAntInfo[chan-1].antLocation[1]);
+            stations[stationNum].strings[stringNum].antennas[antennaNum].SetX(stations[stationNum].GetX()+araGeom->getStationInfo(stationNum, settings1->DETECTOR_YEAR)->fAntInfo[chan-1].antLocation[0]);
+            stations[stationNum].strings[stringNum].antennas[antennaNum].SetY(stations[stationNum].GetY()+araGeom->getStationInfo(stationNum, settings1->DETECTOR_YEAR)->fAntInfo[chan-1].antLocation[1]);
             //stations[stationNum].strings[stringNum].antennas[antennaNum].SetZ(araGeom->fStationInfo[stationNum].fAntInfo[chan-1].antLocation[2]-double(settings1->DEPTH_CHANGE));
-            stations[stationNum].strings[stringNum].antennas[antennaNum].SetZ(araGeom->getStationInfo(stationNum)->fAntInfo[chan-1].antLocation[2]);
+            stations[stationNum].strings[stringNum].antennas[antennaNum].SetZ(araGeom->getStationInfo(stationNum, settings1->DETECTOR_YEAR)->fAntInfo[chan-1].antLocation[2]);
             
             /*
              cout <<
@@ -6723,10 +6723,10 @@ void Detector::UseAntennaInfo(int stationNum, Settings *settings1){
              endl;
              */
             
-            stations[stationNum].strings[stringNum].antennas[antennaNum].type = int(araGeom->getStationInfo(stationNum)->fAntInfo[chan-1].polType);  //set polarization to match the deployed information
+            stations[stationNum].strings[stringNum].antennas[antennaNum].type = int(araGeom->getStationInfo(stationNum, settings1->DETECTOR_YEAR)->fAntInfo[chan-1].polType);  //set polarization to match the deployed information
             
-            stations[stationNum].strings[stringNum].SetX(stations[stationNum].GetX()+araGeom->getStationInfo(stationNum)->fAntInfo[chan-1].antLocation[0]);
-            stations[stationNum].strings[stringNum].SetY(stations[stationNum].GetY()+araGeom->getStationInfo(stationNum)->fAntInfo[chan-1].antLocation[1]);
+            stations[stationNum].strings[stringNum].SetX(stations[stationNum].GetX()+araGeom->getStationInfo(stationNum, settings1->DETECTOR_YEAR)->fAntInfo[chan-1].antLocation[0]);
+            stations[stationNum].strings[stringNum].SetY(stations[stationNum].GetY()+araGeom->getStationInfo(stationNum, settings1->DETECTOR_YEAR)->fAntInfo[chan-1].antLocation[1]);
             
             
             
@@ -6755,10 +6755,10 @@ void Detector::UseAntennaInfo(int stationNum, Settings *settings1){
 
 
             // put DAQ channel type 
-            if (araGeom->getStationInfo(stationNum)->fAntInfo[chan-1].daqChanType == AraDaqChanType::kDisconeChan) { // BH chs
+            if (araGeom->getStationInfo(stationNum, settings1->DETECTOR_YEAR)->fAntInfo[chan-1].daqChanType == AraDaqChanType::kDisconeChan) { // BH chs
                 stations[stationNum].strings[stringNum].antennas[antennaNum].DAQchan = 0;
             }
-            else if (araGeom->getStationInfo(stationNum)->fAntInfo[chan-1].daqChanType == AraDaqChanType::kBatwingChan) { // not BH chs
+            else if (araGeom->getStationInfo(stationNum, settings1->DETECTOR_YEAR)->fAntInfo[chan-1].daqChanType == AraDaqChanType::kBatwingChan) { // not BH chs
                 stations[stationNum].strings[stringNum].antennas[antennaNum].DAQchan = 1;
             }
 
@@ -6771,7 +6771,7 @@ void Detector::UseAntennaInfo(int stationNum, Settings *settings1){
             if (stationNum == 0) {
 
                 //cout<<"TestBed ch"<<chan-1<<" delay : "<<araGeom->fStationInfo[stationNum].fAntInfo[chan-1].debugTotalCableDelay<<endl;
-                params.TestBed_Ch_delay[chan-1] = araGeom->getStationInfo(stationNum)->fAntInfo[chan-1].debugTotalCableDelay;
+                params.TestBed_Ch_delay[chan-1] = araGeom->getStationInfo(stationNum, settings1->DETECTOR_YEAR)->fAntInfo[chan-1].debugTotalCableDelay;
                 params.TestBed_Ch_delay_bin[chan-1] = params.TestBed_Ch_delay[chan-1]/(settings1->TIMESTEP * 1.e9); // change TIMESTEP s to ns
                 //cout<<"TestBed ch"<<chan-1<<" delay bin : "<<params.TestBed_Ch_delay_bin[chan-1]<<endl;
                 if (chan<9) params.TestBed_BH_Mean_delay += params.TestBed_Ch_delay[chan-1];
@@ -6798,11 +6798,11 @@ void Detector::UseAntennaInfo(int stationNum, Settings *settings1){
         }// end polarization (antenna type) selection
         else {
             
-            int antPolNum = araGeom->getStationInfo(stationNum)->fAntInfo[chan-1].antPolNum;
+            int antPolNum = araGeom->getStationInfo(stationNum, settings1->DETECTOR_YEAR)->fAntInfo[chan-1].antPolNum;
             // set surface antenna postions
             
-            stations[stationNum].surfaces[antPolNum].SetX( stations[stationNum].GetX()+araGeom->getStationInfo(stationNum)->fAntInfo[chan-1].antLocation[0]);
-            stations[stationNum].surfaces[antPolNum].SetY( stations[stationNum].GetY()+araGeom->getStationInfo(stationNum)->fAntInfo[chan-1].antLocation[1]);
+            stations[stationNum].surfaces[antPolNum].SetX( stations[stationNum].GetX()+araGeom->getStationInfo(stationNum, settings1->DETECTOR_YEAR)->fAntInfo[chan-1].antLocation[0]);
+            stations[stationNum].surfaces[antPolNum].SetY( stations[stationNum].GetY()+araGeom->getStationInfo(stationNum, settings1->DETECTOR_YEAR)->fAntInfo[chan-1].antLocation[1]);
             
             //                cout << "Surface: " << chan << " : " << stationNum << " : " << stringNum << " : " << antennaNum << " : " << stations[stationNum].surfaces[antPolNum].GetX() << " : " << stations[stationNum].surfaces[antPolNum].GetY() << " : " << stations[stationNum].surfaces[antPolNum].GetZ() << " : " << stations[stationNum].surfaces[antPolNum].type << endl;
             
@@ -6856,10 +6856,10 @@ void Detector::ImportStationInfo(Settings *settings1, int StationIndex, int Stat
 
         if (araGeom->getStationInfo(StationID_AraRoot, settings1->DETECTOR_YEAR)->fAntInfo[antId].polType != AraAntPol::kSurface){
 
-            stations[StationIndex].strings[stringNum].antennas[antennaNum].SetX(stations[StationIndex].GetX()+araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].antLocation[0]);
-            stations[StationIndex].strings[stringNum].antennas[antennaNum].SetY(stations[StationIndex].GetY()+araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].antLocation[1]);
+            stations[StationIndex].strings[stringNum].antennas[antennaNum].SetX(stations[StationIndex].GetX()+araGeom->getStationInfo(StationID_AraRoot, settings1->DETECTOR_YEAR)->fAntInfo[antId].antLocation[0]);
+            stations[StationIndex].strings[stringNum].antennas[antennaNum].SetY(stations[StationIndex].GetY()+araGeom->getStationInfo(StationID_AraRoot, settings1->DETECTOR_YEAR)->fAntInfo[antId].antLocation[1]);
             //stations[stationNum].strings[stringNum].antennas[antennaNum].SetZ(araGeom->fStationInfo[stationNum].fAntInfo[chan-1].antLocation[2]-double(settings1->DEPTH_CHANGE));
-            stations[StationIndex].strings[stringNum].antennas[antennaNum].SetZ(araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].antLocation[2]);
+            stations[StationIndex].strings[stringNum].antennas[antennaNum].SetZ(araGeom->getStationInfo(StationID_AraRoot, settings1->DETECTOR_YEAR)->fAntInfo[antId].antLocation[2]);
             
             /*
              cout <<
@@ -6873,10 +6873,10 @@ void Detector::ImportStationInfo(Settings *settings1, int StationIndex, int Stat
              endl;
              */
             
-            stations[StationIndex].strings[stringNum].antennas[antennaNum].type = int(araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].polType);  //set polarization to match the deployed information
+            stations[StationIndex].strings[stringNum].antennas[antennaNum].type = int(araGeom->getStationInfo(StationID_AraRoot, settings1->DETECTOR_YEAR)->fAntInfo[antId].polType);  //set polarization to match the deployed information
             
-            stations[StationIndex].strings[stringNum].SetX(stations[StationIndex].GetX()+araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].antLocation[0]);
-            stations[StationIndex].strings[stringNum].SetY(stations[StationIndex].GetY()+araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].antLocation[1]);
+            stations[StationIndex].strings[stringNum].SetX(stations[StationIndex].GetX()+araGeom->getStationInfo(StationID_AraRoot, settings1->DETECTOR_YEAR)->fAntInfo[antId].antLocation[0]);
+            stations[StationIndex].strings[stringNum].SetY(stations[StationIndex].GetY()+araGeom->getStationInfo(StationID_AraRoot, settings1->DETECTOR_YEAR)->fAntInfo[antId].antLocation[1]);
             
             
             
@@ -6905,10 +6905,10 @@ void Detector::ImportStationInfo(Settings *settings1, int StationIndex, int Stat
 
 
             // put DAQ channel type 
-            if (araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].daqChanType == AraDaqChanType::kDisconeChan) { // BH chs
+            if (araGeom->getStationInfo(StationID_AraRoot, settings1->DETECTOR_YEAR)->fAntInfo[antId].daqChanType == AraDaqChanType::kDisconeChan) { // BH chs
                 stations[StationIndex].strings[stringNum].antennas[antennaNum].DAQchan = 0;
             }
-            else if (araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].daqChanType == AraDaqChanType::kBatwingChan) { // not BH chs
+            else if (araGeom->getStationInfo(StationID_AraRoot, settings1->DETECTOR_YEAR)->fAntInfo[antId].daqChanType == AraDaqChanType::kBatwingChan) { // not BH chs
                 stations[StationIndex].strings[stringNum].antennas[antennaNum].DAQchan = 1;
             }
 
@@ -6921,7 +6921,7 @@ void Detector::ImportStationInfo(Settings *settings1, int StationIndex, int Stat
             if (StationID == 0) {
 
                 //cout<<"TestBed ch"<<chan-1<<" delay : "<<araGeom->fStationInfo[stationNum].fAntInfo[chan-1].debugTotalCableDelay<<endl;
-                params.TestBed_Ch_delay[chan] = araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].debugTotalCableDelay;
+                params.TestBed_Ch_delay[chan] = araGeom->getStationInfo(StationID_AraRoot, settings1->DETECTOR_YEAR)->fAntInfo[antId].debugTotalCableDelay;
                 params.TestBed_Ch_delay_bin[chan] = params.TestBed_Ch_delay[chan]/(settings1->TIMESTEP * 1.e9); // change TIMESTEP s to ns
                 //cout<<"TestBed ch"<<chan-1<<" delay bin : "<<params.TestBed_Ch_delay_bin[chan-1]<<endl;
                 if (chan<8) params.TestBed_BH_Mean_delay += params.TestBed_Ch_delay[chan];
@@ -6944,11 +6944,11 @@ void Detector::ImportStationInfo(Settings *settings1, int StationIndex, int Stat
         }// end polarization (antenna type) selection
         else {
             
-            int antPolNum = araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].antPolNum;
+            int antPolNum = araGeom->getStationInfo(StationID_AraRoot, settings1->DETECTOR_YEAR)->fAntInfo[antId].antPolNum;
             // set surface antenna postions
             
-            stations[StationIndex].surfaces[antPolNum].SetX( stations[StationIndex].GetX()+araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].antLocation[0]);
-            stations[StationIndex].surfaces[antPolNum].SetY( stations[StationIndex].GetY()+araGeom->getStationInfo(StationID_AraRoot)->fAntInfo[antId].antLocation[1]);
+            stations[StationIndex].surfaces[antPolNum].SetX( stations[StationIndex].GetX()+araGeom->getStationInfo(StationID_AraRoot, settings1->DETECTOR_YEAR)->fAntInfo[antId].antLocation[0]);
+            stations[StationIndex].surfaces[antPolNum].SetY( stations[StationIndex].GetY()+araGeom->getStationInfo(StationID_AraRoot, settings1->DETECTOR_YEAR)->fAntInfo[antId].antLocation[1]);
             
             //                cout << "Surface: " << chan << " : " << stationNum << " : " << stringNum << " : " << antennaNum << " : " << stations[stationNum].surfaces[antPolNum].GetX() << " : " << stations[stationNum].surfaces[antPolNum].GetY() << " : " << stations[stationNum].surfaces[antPolNum].GetZ() << " : " << stations[stationNum].surfaces[antPolNum].type << endl;
             

--- a/Settings.cc
+++ b/Settings.cc
@@ -89,6 +89,7 @@ outputdir="outputs"; // directory where outputs go
   DETECTOR_STATION=-1; // initiate this to negative -1, so it does nothing by default
   DETECTOR_STATION_ARAROOT=-1; // initiate this to negative -1, so it does nothing by default
   DETECTOR_STATION_LIVETIME_CONFIG=-1; // intiative this to negative -1, so it does nothing by default
+  DETECTOR_YEAR=2011;
 
   INTERACTION_MODE=1;   //PickNear mode (0: Aeff mode using sphere surface around station, 1: Veff mode using cylinder volume around station)
 
@@ -397,6 +398,9 @@ void Settings::ReadFile(string setupfile) {
               }
               else if (label == "DETECTOR_STATION_LIVETIME_CONFIG") {
                   DETECTOR_STATION_LIVETIME_CONFIG = atof( line.substr(line.find_first_of("=") + 1).c_str() );
+              }
+              else if (label == "DETECTOR_YEAR") {
+                  DETECTOR_YEAR = atof( line.substr(line.find_first_of("=") + 1).c_str() );
               }
               else if (label == "INTERACTION_MODE") {
                   INTERACTION_MODE = atof( line.substr(line.find_first_of("=") + 1).c_str() );

--- a/Settings.h
+++ b/Settings.h
@@ -63,6 +63,8 @@ class Settings
                               // 0 = testbed, 1 = A1, 2 = A2, 3 = A3	
                                     // Detector=5 indicates Phased array. Detector Station determines setup to use
                                     // 1 = only PA antennas (ARA05 simulated separately), 2 = PA antennas + 1 nontriggering A5 Vpol, 3 = PA antennas + 7 nontriggering A5 Vpols
+                                    
+        int DETECTOR_YEAR; //Year of the station configuration.  Mainly for A1/3, which differentiates the SQL tables for electric channel mapping and such.
         
         int DETECTOR_STATION_ARAROOT; // Also for DETECTOR=4, indicates the single station to be simulated, it just takes care of differentiating ARA_STATION1 (ICRR) vs ARA_STATION1B (ATRI) 
                 // Same values as DETECTOR_STATION. Except that when DETECTOR_STATION = 100, DETECTOR_STATION_ARAROOT = 100 and defaults DETECTOR_STATION back to 1


### PR DESCRIPTION
  This is needed to specify which year of the SQL database to be used for A1 and A3, as it defaults to the 2011 values without it.