### PR TITLE
On-the-fly gain model bug

### DIFF
--- a/Detector.cc
+++ b/Detector.cc
@@ -1786,7 +1786,7 @@ Detector::Detector(Settings * settings1, IceModel * icesurface, string setupfile
           //read the standard ARA electronics
           if(settings1->DETECTOR_STATION > 0){
             char the_gain_filename[500];
-            if(settings1->DETECTOR_STATION_LIVETIME_CONFIG == -1) {
+            if(settings1->DETECTOR_STATION_LIVETIME_CONFIG == -1 || settings1->ELECTRONICS_ANTENNA_CONSISTENCY==1) {
               sprintf(the_gain_filename, "%s/data/gain/ARA_Electronics_TotalGain_TwoFilters.csv", getenv("ARA_SIM_DIR"));
               cout<<" Reading standard ARA electronics response from file:"<<endl;
               cout << the_gain_filename <<endl;
@@ -2139,7 +2139,7 @@ Detector::Detector(Settings * settings1, IceModel * icesurface, string setupfile
         if (settings1 -> CUSTOM_ELECTRONICS == 0) {
             //read the standard ARA electronics
             char the_gain_filename[500];
-            if(settings1->DETECTOR_STATION_LIVETIME_CONFIG == -1) {
+            if(settings1->DETECTOR_STATION_LIVETIME_CONFIG == -1 || settings1->ELECTRONICS_ANTENNA_CONSISTENCY==1) {
               sprintf(the_gain_filename, "%s/data/gain/PA_Electronics_TotalGainPhase.csv", getenv("ARA_SIM_DIR")); 
               cout << " Reading standard PA electronics response from file:" << endl;
               cout << the_gain_filename <<endl;

--- a/Detector.cc
+++ b/Detector.cc
@@ -1796,23 +1796,21 @@ Detector::Detector(Settings * settings1, IceModel * icesurface, string setupfile
               sprintf(the_gain_filename, "%s/data/gain/In_situ_Electronics_A%d_C%d.csv", getenv("ARA_SIM_DIR"), 	
                       settings1->DETECTOR_STATION,  settings1->DETECTOR_STATION_LIVETIME_CONFIG);
               cout << the_gain_filename << endl;
-              
-              ReadElectChain(std::string(the_gain_filename), settings1);
-              //ReadElectChain(string(getenv("ARA_SIM_DIR"))+"/data/gain/ARA_Electronics_TotalGain_TwoFilters.csv", settings1);
-              //ReadElectChain(string(getenv("ARA_SIM_DIR"))+"/data/gain/ARA_Electronics_TotalGainPhase.csv", settings1);
-              if(settings1->ELECTRONICS_ANTENNA_CONSISTENCY==1) {
-                if(settings1->NOISE==1) {
-                  cout << " Recalculating in situ electronic response amplitude to ensure consistency with antenna model used here." << endl;
-                  ReadAmplifierNoiseFigure(settings1); // load amplifier noise figure
-                  CalculateElectChain(settings1); // calculate consistent electronics chain gain amplitude
-                }
-                else {
-                  cerr << "WARNING - Antenna model used to calculate in situ gain model may not match that used in this simulation!" << endl;
-                  cerr << "\t To ensure consistency load an in-situ noise model with NOISE = 1." << endl;
-                } 
+            }  
+            
+            ReadElectChain(std::string(the_gain_filename), settings1);
+            if(settings1->ELECTRONICS_ANTENNA_CONSISTENCY==1) {
+              if(settings1->NOISE==1) {
+                cout << " Recalculating in situ electronic response amplitude to ensure consistency with antenna model used here." << endl;
+                ReadAmplifierNoiseFigure(settings1); // load amplifier noise figure
+                CalculateElectChain(settings1); // calculate consistent electronics chain gain amplitude
               }
-  
+              else {
+                cerr << "WARNING - Antenna model used to calculate in situ gain model may not match that used in this simulation!" << endl;
+                cerr << "\t To ensure consistency load an in-situ noise model with NOISE = 1." << endl;
+              } 
             }
+  
           }
           else{ // testbed only
             cout <<"    In situ gain model does not exist for this station"<<endl;


### PR DESCRIPTION
Updated if statement to load the default gain model when using on-the-fly gain calculation. This is necessary to avoid crashing out if the livetime configuration requested has no corresponding data-driven gain model (which it may not since we have stopped producing them for new livetime configurations).

Also found a bug I apparently inserted in January that didn't actually read-in the default gain models for traditional ARA stations, so fixed that. 