### PR TITLE
Fixed merged A5 channels in PA simulation 

### DIFF
--- a/Detector.cc
+++ b/Detector.cc
@@ -1919,20 +1919,20 @@ Detector::Detector(Settings * settings1, IceModel * icesurface, string setupfile
             // Only PA Attached to PA DAQ in DETECTOR_STATION == 1
             if (settings1->DETECTOR_STATION == 2){ // 1 Vanilla VPol from 1 string attached to PA DAQ
                 stations[i].strings.push_back(temp_string);
-                stations[i].strings[1].antennas.push_back(temp_antenna); // A5E 24, A5RF  7, PA  5 (Formally "String 4")
+                stations[i].strings[1].antennas.push_back(temp_antenna); // A5E 24, A5RF  7, PA  5 
             }
             else if (settings1->DETECTOR_STATION == 3){ // 7 Vanilla VPols from 4 strings attached to PA DAQ
                 stations[i].strings.push_back(temp_string);
-                stations[i].strings[1].antennas.push_back(temp_antenna); // A5E  0, A5RF  5, PA 12, AraSim s0a0
-                stations[i].strings[1].antennas.push_back(temp_antenna); // A5E  1, A5RF  1, PA 13, AraSim s0a2
+                stations[i].strings[1].antennas.push_back(temp_antenna); // A5E  0, A5RF  4, PA 12, AraSim s0a0
+                stations[i].strings[1].antennas.push_back(temp_antenna); // A5E  1, A5RF  0, PA 13, AraSim s0a2
                 stations[i].strings.push_back(temp_string);
                 stations[i].strings[2].antennas.push_back(temp_antenna);   // A5E 16, A5RF  6, PA 10, AraSim s1a0
                 stations[i].strings.push_back(temp_string);
                 stations[i].strings[3].antennas.push_back(temp_antenna);   // A5E 24, A5RF  7, PA  5, AraSim s2a0
                 stations[i].strings[3].antennas.push_back(temp_antenna);   // A5E 25, A5RF  3, PA 11, AraSim s2a2
                 stations[i].strings.push_back(temp_string);
-                stations[i].strings[4].antennas.push_back(temp_antenna);  // A5E  8, A5RF  4, PA 14, AraSim s3a0
-                stations[i].strings[4].antennas.push_back(temp_antenna); // A5E  9, A5RF  0, PA 15, AraSim s3a2
+                stations[i].strings[4].antennas.push_back(temp_antenna);  // A5E  8, A5RF  5, PA 14, AraSim s3a0
+                stations[i].strings[4].antennas.push_back(temp_antenna); // A5E  9, A5RF  1, PA 15, AraSim s3a2
             }
         } // for i in number_of_stations (building vectors)
 
@@ -2031,18 +2031,19 @@ Detector::Detector(Settings * settings1, IceModel * icesurface, string setupfile
                 // Set ARA5 string locations
                 // DETECTOR_STATION == 1 has no ARA5 strings attached to PA DAQ
                 if (settings1->DETECTOR_STATION == 2){
-                    stations[i].strings[1].SetX( stations[i].GetX() + 12.33); 
+                    stations[i].strings[1].SetX( stations[i].GetX() + 12.33); // A5E 24 
                     stations[i].strings[1].SetY( stations[i].GetY() - 31.89); 
                 }
                 else if (settings1->DETECTOR_STATION == 3){
-                    stations[i].strings[1].SetX( stations[i].GetX() +  1.55); // A5E 0-3
-                    stations[i].strings[1].SetY( stations[i].GetY() + 15.66);
-                    stations[i].strings[2].SetX( stations[i].GetX() - 12.96); // A5E 16-19
+                    stations[i].strings[1].SetX( stations[i].GetX() + 29.63); // A5E 0 & 1
+                    stations[i].strings[1].SetY( stations[i].GetY() -  3.30);
+                    stations[i].strings[2].SetX( stations[i].GetX() - 12.96); // A5E 16
                     stations[i].strings[2].SetY( stations[i].GetY() -  8.65);
-                    stations[i].strings[3].SetX( stations[i].GetX() + 12.33); // A5E 24-27 
+                    stations[i].strings[3].SetX( stations[i].GetX() + 12.33); // A5E 24 & 25 
                     stations[i].strings[3].SetY( stations[i].GetY() - 31.89);
-                    stations[i].strings[4].SetX( stations[i].GetX() + 29.63); // A5E 8-11
-                    stations[i].strings[4].SetY( stations[i].GetY() -  3.30);
+                    stations[i].strings[4].SetX( stations[i].GetX() +  1.55); // A5E 8 & 9
+                    stations[i].strings[4].SetY( stations[i].GetY() + 15.66);
+
                 }
 
                 // Set ARA5 antenna depths
@@ -2054,13 +2055,13 @@ Detector::Detector(Settings * settings1, IceModel * icesurface, string setupfile
                 }
                 else if (settings1->DETECTOR_STATION == 3){
                     cout << "Using 7 ARA05 vanilla Vpols" << endl;
-                    stations[i].strings[1].antennas[0].SetZ(-196.2045); // A5E  0, A5RF  5, PA 12, AraSim s0a0
-                    stations[i].strings[1].antennas[1].SetZ(-166.5366); // A5E  1, A5RF  1, PA 13, AraSim s0a2
+                    stations[i].strings[1].antennas[0].SetZ(-194.739); // A5E  0, A5RF  4, PA 12, AraSim s0a0
+                    stations[i].strings[1].antennas[1].SetZ(-165.0948); // A5E  1, A5RF  0, PA 13, AraSim s0a2
                     stations[i].strings[2].antennas[0].SetZ(-177.75);   // A5E 16, A5RF  6, PA 10, AraSim s1a0
                     stations[i].strings[3].antennas[0].SetZ(-190.86);   // A5E 24, A5RF  7, PA  5, AraSim s2a0
                     stations[i].strings[3].antennas[1].SetZ(-161.02);   // A5E 25, A5RF  3, PA 11, AraSim s2a2
-                    stations[i].strings[4].antennas[0].SetZ(-194.739);  // A5E  8, A5RF  4, PA 14, AraSim s3a0
-                    stations[i].strings[4].antennas[1].SetZ(-165.0948); // A5E  9, A5RF  0, PA 15, AraSim s3a2
+                    stations[i].strings[4].antennas[0].SetZ(-196.2045);  // A5E  8, A5RF  5, PA 14, AraSim s3a0
+                    stations[i].strings[4].antennas[1].SetZ(-166.5366); // A5E  9, A5RF  1, PA 15, AraSim s3a2
                 }
 
                 // Set all antennas to VPOL (1 for HPOL)
@@ -4097,7 +4098,7 @@ void Detector::ReadAmplifierNoiseFigure(Settings *settings) {
     // define PA channels to be replaced
     vector<int> chans = {5, 10, 11, 12, 13, 14, 15};
     // define corresponding A5 RF channels  
-    vector<int> srcChans = {7, 6, 3, 5, 1, 4, 0};
+    vector<int> srcChans = {7, 6, 3, 4, 0, 5, 1};
   
     if(chans.size() != srcChans.size())
       throw runtime_error("Mismatch in A5-PA channel mapping for amplifier noise!"); 


### PR DESCRIPTION
Fixed merged A5 channels in PA simulation to have correct positions based on correction made in AraRoot. The normal A5 simulation uses the geometry from the AraRoot SQL database and so doesn't need to be addressed directly.