### PR TITLE
Remove livetime config checks

### DIFF
--- a/Settings.cc
+++ b/Settings.cc
@@ -887,23 +887,6 @@ int Settings::CheckCompatibilitiesSettings() {
 
     int num_err = 0;
 
-
-    /*
-    // if INTERACTION_MODE is 0 (sphere area and obtain Aeff), make sure using GETCHORD_MODE=1
-    if (INTERACTION_MODE==0) { // picknear_sphere mode
-        if (GETCHORD_MODE==0) { // but use old getchord mode (not working!)
-            cerr<<"In INTERACTION_MODE=0, you have to use GETCHORD_MODE=1"<<endl; 
-            num_err++;
-        }
-    }
-    else if (INTERACTION_MODE==1) { // picknear_cylinder mode
-        if (GETCHORD_MODE==1) { // but use new getchord mode (not working!)
-            cerr<<"In INTERACTION_MODE=1, you have to use GETCHORD_MODE=0"<<endl; 
-            num_err++;
-        }
-    }
-    */
-
     // if BH_ANT_SEP_DIST_ON=1, we can't use READGEOM=1 (actual installed geom)
     if (BH_ANT_SEP_DIST_ON==1 && READGEOM==1) {
         cerr<<"BH_ANT_SEP_DIST_ON=1 is only available in ideal station geom (READGEOM=0)!"<<endl; 
@@ -934,24 +917,12 @@ int Settings::CheckCompatibilitiesSettings() {
 
 
     // check modes which will only work for actual installed TestBed case
-    //
     if (TRIG_ONLY_BH_ON==1 && DETECTOR!=3) {
         cerr<<"TRIG_ONLY_BH_ON=1 only works with DETECTOR=3!"<<endl;
         num_err++;
     }
 
-    /*
-    //if (NOISE_CHANNEL_MODE==1 && DETECTOR!=3) {
-    if (NOISE_CHANNEL_MODE==1 && DETECTOR!=3 && TRIG_ONLY_LOW_CH_ON!=1) {
-        //cerr<<"NOISE_CHANNEL_MODE=1 only works with DETECTOR=3!"<<endl;
-        cerr<<"NOISE_CHANNEL_MODE=1 only works with DETECTOR=3 or TRIG_ONLY_LOW_CH_ON=1"<<endl;
-        num_err++;
-    }
-    */
-
-    //if (NOISE_CHANNEL_MODE==2 && DETECTOR!=3) {
     if (NOISE_CHANNEL_MODE==2 && DETECTOR!=3 && TRIG_ONLY_LOW_CH_ON!=1) {
-        //cerr<<"NOISE_CHANNEL_MODE=2 only works with DETECTOR=3!"<<endl;
         cerr<<"NOISE_CHANNEL_MODE=2 only works with DETECTOR=3 or TRIG_ONLY_LOW_CH_ON=1"<<endl;
         num_err++;
     }
@@ -972,13 +943,11 @@ int Settings::CheckCompatibilitiesSettings() {
     }
 
     if (TRIG_THRES_MODE==1 && DETECTOR!=3 && TRIG_ONLY_LOW_CH_ON!=1) {
-        //cerr<<"TRIG_THRES_MODE=1 and 2 only works with DETECTOR=3!"<<endl;
         cerr<<"TRIG_THRES_MODE=1 only works with DETECTOR=3 or TRIG_ONLY_LOW_CH_ON=1"<<endl;
         num_err++;
     }
 
     if (TRIG_THRES_MODE==2 && DETECTOR!=3 && TRIG_ONLY_LOW_CH_ON!=1) {
-        //cerr<<"TRIG_THRES_MODE=1 and 2 only works with DETECTOR=3!"<<endl;
         cerr<<"TRIG_THRES_MODE=2 only works with DETECTOR=3 or TRIG_ONLY_LOW_CH_ON=1"<<endl;
         num_err++;
     }
@@ -1003,11 +972,6 @@ int Settings::CheckCompatibilitiesSettings() {
         num_err++;
     }
 
-    // if (NOISE==1 && DETECTOR!=3 && TRIG_ONLY_LOW_CH_ON!=1) {
-    //     cerr<<"NOISE=1 only works with DETECTOR=3 or TRIG_ONLY_LOW_CH_ON=1"<<endl;
-    //     num_err++;
-    // }
-
     if (NOISE==1 && USE_TESTBED_RFCM_ON==1) {
         cerr<<"NOISE=1 only works with USE_TESTBED_RFCM_ON=0!"<<endl;
         num_err++;
@@ -1026,83 +990,39 @@ int Settings::CheckCompatibilitiesSettings() {
     }
     if (DATA_LIKE_OUTPUT != 0 && (DETECTOR==0 || DETECTOR==1 || DETECTOR==2)) {
         cerr<<"DATA_LIKE_OUTPUT=1,2 doesn't work with DETECTOR=0,1,2"<<endl;
-        cerr<<"DATA_LIKE_OUTPUT controls data-like output into UsefulAtriStationEvent format; without a real station selected (using DETECTOR==3,4), the mapping to the data-like output will not function correctly"<<endl;
+        cerr<<"DATA_LIKE_OUTPUT controls data-like output into UsefulAtriStationEvent format;" 
+            <<" without a real station selected (using DETECTOR==3,4), the mapping to the data-like output will not function correctly"<<endl;
         num_err++;
     }
 
     if (DATA_LIKE_OUTPUT != 0 && (DETECTOR_STATION>5)) {
         cerr<<"DATA_LIKE_OUTPUT=1,2 doesn't work with DETECTOR_STATION>3"<<endl;
-        cerr<<"DATA_LIKE_OUTPUT controls data-like output into UsefulAtriStationEvent format; without a real station selected (using DETECTOR==3,4), the mapping to the data-like output will not function correctly"<<endl;
+        cerr<<"DATA_LIKE_OUTPUT controls data-like output into UsefulAtriStationEvent format;"
+            <<" without a real station selected (using DETECTOR==3,4), the mapping to the data-like output will not function correctly"<<endl;
         num_err++;
     }
-    /*
-    if(NOISE == 2 && (DETECTOR==0 || DETECTOR==1 || DETECTOR==2)){
-      cerr << "CALIBRATION_MODE=1 doesn't work with DETECTOR=0,1,2" << endl;
-      cerr << "CALIBRATION_MODE controls the response from installed stations 2,3 and thus has no real relevance for DETECTOR=0,1,2" << endl;
-      num_err++;
-    }
-    */
 
-    // Verify valid DETECTOR_STATION_LIVETIME_CONFIG values for Installed A1-A5 stations
     if (DETECTOR == 4 ) {
       if (ARAUTIL_EXISTS == false){
-	    cerr << "DETECTOR=4 only works with an installation of AraRoot" << endl;
-	    num_err++;
-      } else {
+        cerr << "DETECTOR=4 only works with an installation of AraRoot" << endl;
+        num_err++;
+      } 
+      else {
 	
-	    cerr << "DETECTOR is set to 4" << endl; 
-	    cerr << "Setting READGEOM to 1" << endl;
-	    READGEOM=1;
+        cerr << "DETECTOR is set to 4" << endl; 
+        cerr << "Setting READGEOM to 1" << endl;
+        READGEOM=1;
 
-	    cerr << "Setting number_of_stations to 1" << endl;
-	    number_of_stations = 1;
+        cerr << "Setting number_of_stations to 1" << endl;
+        number_of_stations = 1;
 
-	    if (DETECTOR_STATION <0 || DETECTOR_STATION >= NUM_INSTALLED_STATIONS){
-	        cerr << "DETECTOR_STATION is not set to a valid station number" << endl;
-	        num_err++;
-	    }
-        if(DETECTOR_STATION_LIVETIME_CONFIG>-1){
-	        if((int)DETECTOR_STATION==1){
-                if(DETECTOR_STATION_LIVETIME_CONFIG>5 || DETECTOR_STATION_LIVETIME_CONFIG<1){
-                    cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<" but there are only seven expected configurations for A1"<<endl;
-                    num_err++;
-                }
-            }
-            else if((int)DETECTOR_STATION==2){
-                if(DETECTOR_STATION_LIVETIME_CONFIG>6 || DETECTOR_STATION_LIVETIME_CONFIG<1){
-                    cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<" but there are only six expected configurations for A2"<<endl;
-                    num_err++;
-                }
-            }
-            else if((int)DETECTOR_STATION==3){
-                if(DETECTOR_STATION_LIVETIME_CONFIG>7 || DETECTOR_STATION_LIVETIME_CONFIG<1){
-                    cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<" but there are only seven expected configurations for A3"<<endl;
-                    num_err++;
-                }
-            }
-            else if((int)DETECTOR_STATION==4){
-                if(DETECTOR_STATION_LIVETIME_CONFIG>4 || DETECTOR_STATION_LIVETIME_CONFIG<1){
-                    cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<" but there are only four expected configurations for A3"<<endl;
-                    num_err++;
-                }
-            }
-            else if((int)DETECTOR_STATION==5){
-                if(DETECTOR_STATION_LIVETIME_CONFIG>2 || DETECTOR_STATION_LIVETIME_CONFIG<1){
-                    cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<" but there are only two expected configurations for A3"<<endl;
-                    num_err++;
-                }
-            }
-            else{
-                cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is set to "<<DETECTOR_STATION_LIVETIME_CONFIG<<" but DETECTOR_STATION is "<<DETECTOR_STATION<<endl;
-                cerr<<" Unfamiliar DETECTOR_STATION value"<<endl;
-                num_err++;
-            }
+        if (DETECTOR_STATION <0 || DETECTOR_STATION >= NUM_INSTALLED_STATIONS){
+          cerr << "DETECTOR_STATION is not set to a valid station number" << endl;
+          num_err++;
         }
-		
       }
     }
 
-    // Verify valid DETECTOR_STATION_LIVETIME_CONFIG values for Installed PA
     if ( (int)DETECTOR == 5 ){
 
 	    cerr << "DETECTOR is set to 5" << endl; 
@@ -1112,58 +1032,51 @@ int Settings::CheckCompatibilitiesSettings() {
 	        cerr << "DETECTOR_STATION is not set to a valid station number" << endl;
 	        num_err++;
 	    }
-
-        if ( DETECTOR_STATION_LIVETIME_CONFIG > -1 ) {
-            if ( DETECTOR_STATION_LIVETIME_CONFIG>5 || DETECTOR_STATION_LIVETIME_CONFIG<1 ) {
-                cerr<<" DETECTOR_STATION_LIVETIME_CONFIG is set to ";
-                cerr<<DETECTOR_STATION_LIVETIME_CONFIG;
-                cerr<<" but there are only five expected configurations for the PA"<<endl;
-                num_err++;
-            } 
-        }
-
     } // end if DETECTOR==5
 
-   //Check that DETECTOR_STATION=0 is only used with DETECTOR=3
-   if (DETECTOR_STATION==0 && DETECTOR!=3){
+    //Check that DETECTOR_STATION=0 is only used with DETECTOR=3
+    if (DETECTOR_STATION==0 && DETECTOR!=3){
       cerr << " DETECTOR_STATION=0 doesn't work with DETECTOR!=3. If you want to work with TestBed, use DETECTOR=3 & DETECTOR_STATION=0" << endl;
       num_err++;
-   }
-   if (DETECTOR==0){
-    cerr << "DETECTOR=0 is un-used in AraSim."<<endl;
-    num_err++;
-   }
-   if (DETECTOR_STATION>=0 && DETECTOR<3){
-    cerr << "DETECTOR_STATION>=0 is only compatible with DETECTOR=3 (Testbed) or DETECTOR=4 (deep stations)"<<endl;
-    num_err++;
-   }
+    }
+    if (DETECTOR==0){
+      cerr << "DETECTOR=0 is un-used in AraSim."<<endl;
+      num_err++;
+    }
+    if (DETECTOR_STATION>=0 && DETECTOR<3){
+      cerr << "DETECTOR_STATION>=0 is only compatible with DETECTOR=3 (Testbed) or DETECTOR=4 (deep stations)"<<endl;
+      num_err++;
+    }
 
-   // check that USE_PARAM_RE_TTERM_TABLE is only used with SIMULATION_MODE==1
-   if (USE_PARAM_RE_TTERM_TABLE==1 && SIMULATION_MODE!=1){
-    cerr << "USE_PARAM_RE_TTERM_TABLE=0 doesn't work with SIMULATION_MODE!=1"<<endl;
-    num_err++;
-   }
+    // check that USE_PARAM_RE_TTERM_TABLE is only used with SIMULATION_MODE==1
+    if (USE_PARAM_RE_TTERM_TABLE==1 && SIMULATION_MODE!=1){
+      cerr << "USE_PARAM_RE_TTERM_TABLE=0 doesn't work with SIMULATION_MODE!=1"<<endl;
+      num_err++;
+    }
 
    //Compatibilities for birefringence
-   if (BIREFRINGENCE==1){
-	if(DETECTOR!=4){
-	   cerr << "BIREFRINGENCE=1 is only supported for individual stations" <<endl;
-	   num_err++; 
-	}	
-	if (BIAXIAL<0 || BIAXIAL>1){
-	 cerr << "BIREFRINGENCE only supports BIAXIAL=0 (uniaxial) or BIAXIAL=1 (biaxial)" << endl;
-	 num_err++;
-	}
-	if (RAY_TRACE_ICE_MODEL_PARAMS!=50){
-	 cerr << "BIREFRINGENCE=1 should only work with RAY_TRACE_ICE_MODEL_PARAMS=50" <<endl;	
-	 num_err++;
-	}
-   }
-   if (BIREFRINGENCE!=1 && BIREFRINGENCE!=0){
-    cerr << "BIREFRINGENCE only takes 0 or 1" << endl;
-    num_err++;
-   }
+    if (BIREFRINGENCE==1){
+      if(DETECTOR!=4){
+        cerr << "BIREFRINGENCE=1 is only supported for individual stations" <<endl;
+        num_err++; 
+      }	
+      if (BIAXIAL<0 || BIAXIAL>1){
+        cerr << "BIREFRINGENCE only supports BIAXIAL=0 (uniaxial) or BIAXIAL=1 (biaxial)" << endl;
+        num_err++;
+      }
+      if (RAY_TRACE_ICE_MODEL_PARAMS!=50){
+          cerr << "BIREFRINGENCE=1 should only work with RAY_TRACE_ICE_MODEL_PARAMS=50" <<endl;	
+          num_err++;
+      }
+    }
+    if (BIREFRINGENCE!=1 && BIREFRINGENCE!=0){
+      cerr << "BIREFRINGENCE only takes 0 or 1" << endl;
+      num_err++;
+    }
 
     return num_err;
 
 }
+
+
+


### PR DESCRIPTION
Removed the livetime configuration checks in `Settings::CheckCompatibilitiesSettings()` to make code easier to scale in the future. This should be okay because if an invalid livetime configuration is chosen AraSim should crash when it attempts to find the data files corresponding to that livetime configuration. 

Also tried to clean up the code in that area a bit.