### PR TITLE
Set noise event weight to 1

### DIFF
--- a/Event.cc
+++ b/Event.cc
@@ -115,6 +115,13 @@ Event::Event (Settings *settings1, Spectra *spectra1, Primaries *primary1, IceMo
         //Report *report_tmp;
 
         Nu_temp = new Interaction (pnu, nuflavor, nu_nubar, n_interactions, icemodel, detector, settings1, primary1, signal, sec1 );
+      
+        // set weights to 1 if this is a noise only simulation
+        if(settings1->TRIG_ANALYSIS_MODE==2) {
+            Nu_temp->weight = 1.;
+            Nu_temp->probability = 1.;
+        }
+
         //report_tmp = new Report(detector ,settings1);
         if(Nu_temp->sigma_err==1){
             // only if getting sigma was successful

--- a/Event.cc
+++ b/Event.cc
@@ -116,12 +116,6 @@ Event::Event (Settings *settings1, Spectra *spectra1, Primaries *primary1, IceMo
 
         Nu_temp = new Interaction (pnu, nuflavor, nu_nubar, n_interactions, icemodel, detector, settings1, primary1, signal, sec1 );
       
-        // set weights to 1 if this is a noise only simulation
-        if(settings1->TRIG_ANALYSIS_MODE==2) {
-            Nu_temp->weight = 1.;
-            Nu_temp->probability = 1.;
-        }
-
         //report_tmp = new Report(detector ,settings1);
         if(Nu_temp->sigma_err==1){
             // only if getting sigma was successful

--- a/Primaries.cc
+++ b/Primaries.cc
@@ -1153,6 +1153,12 @@ Interaction::Interaction (double pnu, string nuflavor, int nu_nubar, int &n_inte
     } // tdomain mode
   }// if pickposnu
 
+  // set weights to 1 if this is a noise only simulation
+  if(settings1->TRIG_ANALYSIS_MODE==2) {
+      weight = 1.;
+      probability = 1.;
+  }
+
 }
 
 // Arbitrary event Interaction class


### PR DESCRIPTION
Force events to have weight 1 when in noise-only (`TRIG_ANALYSIS_MODE=2`) mode. This also sets `probability` to 1 in case this is ever run when `INTERACTION_MODE!=1`.