### PR TITLE
Added consistency check for PA

### DIFF
--- a/Report.cc
+++ b/Report.cc
@@ -5097,6 +5097,7 @@ void Report::checkPATrigger(
     // for PA trigger check only 20 ns around the signal bin.
     // This is to avoid getting the second ray
     // KAH and ARB are not sure where the 1200 number comes from
+    // !!!HEY IF YOU ARE FIXING THIS!!! please update the corresponding check in Settings::CheckCompatibilitiesSettings 
     int BINSIZE = 1200/(settings1->TIMESTEP*1.e9);  // Number of bins (aka datapoints) of data to save
 
     int waveformLength = settings1->WAVEFORM_LENGTH;

--- a/Settings.cc
+++ b/Settings.cc
@@ -937,13 +937,15 @@ int Settings::CheckCompatibilitiesSettings() {
     // NFOUR is at least twice this to avoid FFT issues
     const int PA_INTERNAL_LENGTH = 1200/(TIMESTEP*1.e9);  
     if ( DETECTOR==5 && 2*PA_INTERNAL_LENGTH > NFOUR) {
-        cerr<<"NFOUR should be at least twice PA_INTERNAL_LENGTH to avoid FFT artifacts or problems with readout!"<<endl; 
+        cerr<<"NFOUR should be at least twice PA_INTERNAL_LENGTH to avoid FFT artifacts or problems with readout!" 
+            << " Your PA_INTERNAL_LENGTH = " << PA_INTERNAL_LENGTH <<endl; 
         num_err++;
     }
 
     // Also ensure that the requested waveform length isn't longer than the internal length
     if ( DETECTOR==5 && PA_INTERNAL_LENGTH < WAVEFORM_LENGTH) {
-        cerr<<"WAVEFORM_LENGTH cannot be longer than PA_INTERNAL_LENGTH to avoid problems with readout!"<<endl; 
+        cerr<<"WAVEFORM_LENGTH cannot be longer than PA_INTERNAL_LENGTH to avoid problems with readout!"
+            << " Your PA_INTERNAL_LENGTH = " << PA_INTERNAL_LENGTH <<endl; 
         num_err++;
     }
 

--- a/Settings.cc
+++ b/Settings.cc
@@ -931,6 +931,15 @@ int Settings::CheckCompatibilitiesSettings() {
         cerr<<"NFOUR should be at least twice WAVEFORM_LENGTH to avoid FFT artifacts or problems with readout!"<<endl; 
         num_err++;
     }
+ 
+    // for PA simulations we need to be careful since BINSIZE isnt the usual NFOUR/2 
+    // but is hardcoded to 1200/(settings1->TIMESTEP*1.e9), so we need to make sure 
+    // NFOUR is at least twice this to avoid FFT issues
+    const int PA_INTERNAL_LENGTH = 1200/(TIMESTEP*1.e9);  
+    if ( DETECTOR==5 && 2*PA_INTERNAL_LENGTH > NFOUR) {
+        cerr<<"NFOUR should be at least twice PA_INTERNAL_LENGTH to avoid FFT artifacts or problems with readout!"<<endl; 
+        num_err++;
+    }
 
     // if BH_ANT_SEP_DIST_ON=1, we can't use READGEOM=1 (actual installed geom)
     if (BH_ANT_SEP_DIST_ON==1 && READGEOM==1) {

--- a/Settings.cc
+++ b/Settings.cc
@@ -941,6 +941,13 @@ int Settings::CheckCompatibilitiesSettings() {
         num_err++;
     }
 
+    // Also ensure that the requested waveform length isn't longer than the internal length
+    if ( DETECTOR==5 && PA_INTERNAL_LENGTH < WAVEFORM_LENGTH) {
+        cerr<<"WAVEFORM_LENGTH cannot be longer than PA_INTERNAL_LENGTH to avoid problems with readout!"<<endl; 
+        num_err++;
+    }
+
+
     // if BH_ANT_SEP_DIST_ON=1, we can't use READGEOM=1 (actual installed geom)
     if (BH_ANT_SEP_DIST_ON==1 && READGEOM==1) {
         cerr<<"BH_ANT_SEP_DIST_ON=1 is only available in ideal station geom (READGEOM=0)!"<<endl; 


### PR DESCRIPTION
This adds a check to make sure the NFOUR is large enough for the PA, which uses a different internal array size than most stations, which typically use `NFOUR/2`. Compare this for vanilla stations:
https://github.com/ara-software/AraSim/blob/871fe4863d11734b02f7456ec3979f475f1e9255/Report.cc#L2896

to this for the PA:
https://github.com/ara-software/AraSim/blob/871fe4863d11734b02f7456ec3979f475f1e9255/Report.cc#L5100