### PR TITLE
Center PA waveforms in the eventTree

### DIFF
--- a/AraSim.cc
+++ b/AraSim.cc
@@ -352,7 +352,7 @@ int main(int argc, char **argv) {   // read setup.txt file
 
         if ( settings1->EVENT_GENERATION_MODE == 2 ){
             // Write event lists to file, no simulation
-            
+
             // get station center for conversion to local coordinates
             double sumX = 0.;
             double sumY = 0.; 
@@ -369,9 +369,9 @@ int main(int argc, char **argv) {   // read setup.txt file
             }
 
             // station center coordinates
-            double avgX = sumX/double(count);
-            double avgY = sumY/double(count);
-            double avgZ = sumZ/double(count);
+            const double avgX = sumX/double(count);
+            const double avgY = sumY/double(count);
+            const double avgZ = sumZ/double(count);
             const Vector detectorCenter(avgX, avgY, avgZ);
 
             for (int interaction_i=0; interaction_i<event->Nu_Interaction.size(); interaction_i++){

--- a/AraSim.cc
+++ b/AraSim.cc
@@ -352,16 +352,41 @@ int main(int argc, char **argv) {   // read setup.txt file
 
         if ( settings1->EVENT_GENERATION_MODE == 2 ){
             // Write event lists to file, no simulation
+            
+            // get station center for conversion to local coordinates
+            double sumX = 0.;
+            double sumY = 0.; 
+            double sumZ = 0.;
+            int count = 0;
+
+            for (int i = 0; i < detector->stations[0].strings.size(); i++){
+              for (int j = 0; j < detector->stations[0].strings[i].antennas.size(); j++){
+                sumX = sumX + detector->stations[0].strings[i].antennas[j].GetX();
+                sumY = sumY + detector->stations[0].strings[i].antennas[j].GetY();
+                sumZ = sumZ + detector->stations[0].strings[i].antennas[j].GetZ();
+                count++;
+              }
+            }
+
+            // station center coordinates
+            double avgX = sumX/double(count);
+            double avgY = sumY/double(count);
+            double avgZ = sumZ/double(count);
+            const Vector detectorCenter(avgX, avgY, avgZ);
+
             for (int interaction_i=0; interaction_i<event->Nu_Interaction.size(); interaction_i++){
-                
+
+                // convert to detector-centered coordinates
+                const Vector localPos = event->Nu_Interaction[interaction_i].posnu - detectorCenter;
+ 
                 event_file << inu << " "; // EVID    
                 event_file << event->nuflavorint << " "; // NUFLAVORINT       
                 event_file << event->nu_nubar << " "; // NUBAR       
                 event_file << event->pnu << " "; // PNU      
                 event_file << event->Nu_Interaction[interaction_i].currentint    << " "; // CURRENTINT       
-                event_file << event->Nu_Interaction[interaction_i].posnu.R()     << " "; // IND_POSNU_R      
-                event_file << event->Nu_Interaction[interaction_i].posnu.Theta() << " "; // IND_POSNU_THETA       
-                event_file << event->Nu_Interaction[interaction_i].posnu.Phi()   << " "; // IND_POSNU_PHI      
+                event_file << localPos.R()     << " "; // IND_POSNU_R      
+                event_file << localPos.Theta() << " "; // IND_POSNU_THETA       
+                event_file << localPos.Phi()   << " "; // IND_POSNU_PHI      
                 event_file << event->Nu_Interaction[interaction_i].nnu.Theta()   << " "; // IND_NNU_THETA      
                 event_file << event->Nu_Interaction[interaction_i].nnu.Phi()     << " "; // IND_NNU_PHI       
                 event_file << event->Nu_Interaction[interaction_i].elast_y       << endl; // ELAST

--- a/Report.cc
+++ b/Report.cc
@@ -5214,9 +5214,9 @@ void Report::checkPATrigger(
                 for (size_t str = 0; str < detector->stations[i].strings.size(); str++) {
                     for (size_t ant = 0; ant < detector->stations[i].strings[str].antennas.size(); ant++) {
                         double peakvalue = 0;
-                        for (int bin=0; bin<BINSIZE; bin++) {
+                        for (int bin=0; bin<waveformLength; bin++) {
 
-                            int bin_value = last_trig_bin - BINSIZE/2 + bin;
+                            int bin_value = last_trig_bin - waveformLength/2 + bin;
                             stations[i].strings[str].antennas[ant].V_mimic.push_back(trigger->Full_window_V[my_ch_id][bin_value]);// save in V (KAH)
                             stations[i].strings[str].antennas[ant].time.push_back( bin_value );
                             stations[i].strings[str].antennas[ant].time_mimic.push_back( ( bin) * settings1->TIMESTEP*1.e9 );// save in ns

--- a/Report.cc
+++ b/Report.cc
@@ -5216,7 +5216,7 @@ void Report::checkPATrigger(
                         double peakvalue = 0;
                         for (int bin=0; bin<waveformLength; bin++) {
 
-                            int bin_value = last_trig_bin - waveformLength/2 + bin;
+                            int bin_value = last_trig_bin + waveformCenter - waveformLength/2 + bin;
                             stations[i].strings[str].antennas[ant].V_mimic.push_back(trigger->Full_window_V[my_ch_id][bin_value]);// save in V (KAH)
                             stations[i].strings[str].antennas[ant].time.push_back( bin_value );
                             stations[i].strings[str].antennas[ant].time_mimic.push_back( ( bin) * settings1->TIMESTEP*1.e9 );// save in ns

--- a/Settings.cc
+++ b/Settings.cc
@@ -163,7 +163,7 @@ outputdir="outputs"; // directory where outputs go
 
   PICK_POSNU_DEPTH=0;     //default : 0 pick posnu depth from 0 to ice depth
 
-  MAX_POSNU_DEPTH=200.;     // default : 200m depth max
+  MAX_POSNU_DEPTH=0.;     // default : 0m depth max
 
   NNU_THIS_THETA=0;         // default 0: nnu angle pure random, 1: set a specific theta
 
@@ -531,10 +531,10 @@ void Settings::ReadFile(string setupfile) {
                   NNU_D_PHI = atof( line.substr(line.find_first_of("=") + 1).c_str() );
               }
 
-	      else if (label == "Z_THIS_TOLERANCE") {
+              else if (label == "Z_THIS_TOLERANCE") {
                   Z_THIS_TOLERANCE = atof( line.substr(line.find_first_of("=") + 1).c_str() );
               }
-	      else if (label == "Z_TOLERANCE") {
+              else if (label == "Z_TOLERANCE") {
                   Z_TOLERANCE = atof( line.substr(line.find_first_of("=") + 1).c_str() );
               }
 
@@ -910,11 +910,18 @@ int Settings::CheckCompatibilitiesDetector(Detector *detector) {
 
     // check if there's enough system temperature values prepared for NOISE_CHANNEL_MODE=1
     if (NOISE_CHANNEL_MODE==1) {// use different system temperature values for different chs
-      if (DETECTOR==3 && (detector->params.number_of_antennas > (int)(detector->Temp_TB_ch.size())) ) {
-	  cout << detector->params.number_of_antennas << " : " <<(int)(detector->Temp_TB_ch.size()) << endl;
+        if (DETECTOR==3 && (detector->params.number_of_antennas > (int)(detector->Temp_TB_ch.size())) ) {
+            cout << detector->params.number_of_antennas << " : " <<(int)(detector->Temp_TB_ch.size()) << endl;
             cerr<<"System temperature values are not enough for all channels! Check number of channels you are using and numbers in data/system_temperature.csv"<<endl;
             num_err++;
         }
+    }
+
+    // check if the user set a cylinder height but didn't tell AraSim to use it!
+    if (MAX_POSNU_DEPTH > 0 && PICK_POSNU_DEPTH != 1) {
+        cerr << "Non-zero MAX_POSNU_DEPTH set but PICK_POSNU_DEPTH != 1, so this will be ignored and cylinder height will be ice thickness!" << endl;
+        cerr << "Please change settings to either not set MAX_POSNU_DEPTH or set PICK_POSNU_DEPTH to 1." << endl;
+        num_err++;
     }
 
     return num_err;

--- a/Settings.h
+++ b/Settings.h
@@ -483,7 +483,7 @@ class Settings
  // end of values from icemc
 
 
-  ClassDef(Settings,2);
+  ClassDef(Settings,3);
 
 
 };


### PR DESCRIPTION
Corrected the readout of triggered PA wavefroms into `V_mimic` so that they are properly centered on (and offset from, if requested) the triggering signal in channel 0 in the eventTree output. Previously the centering assumed a 1200 ns readout window.

As part of this I ended up incrementing the ClassDef version in Settings (was getting a lot of annoying warnings) and also changed the AraSim event list generation to output events in detector-centered coordinates. The latter change allows event lists generated by AraSim to be directly read-in by AraSim. A settings compatibility check was also added to make users aware of the fact that an additional setting (`PICK_POSNU_DEPTH=1`) is required in the setup file if they want to set the throw cylinder height via `MAX_POSNU_DEPTH`.

This is an example of how the trace looked in the eventTree before the change:
<img width="692" alt="Screenshot 2025-04-15 at 4 10 05 PM" src="https://github.com/user-attachments/assets/d7103de4-cc30-4c24-9884-0b6368c122eb" />

and after:
<img width="695" alt="Screenshot 2025-04-15 at 4 16 40 PM" src="https://github.com/user-attachments/assets/f675b283-ad06-4243-ad74-862db6e974c3" />
