### PR TITLE
Added check for ARA_SIM_DIR variable

### DIFF
--- a/AraSim.cc
+++ b/AraSim.cc
@@ -46,7 +46,21 @@ void save_useful_event(int, UsefulIcrrStationEvent*, UsefulAtriStationEvent*, do
 string outputdir="outputs";
 
 int main(int argc, char **argv) {   // read setup.txt file
-    
+
+    // check that the environmental variable needed to find data files
+    // is defined before we do anything
+    if(!getenv("ARA_SIM_DIR")) {
+        throw runtime_error("The environmental variable ARA_SIM_DIR must be set!");
+    }
+    // check if a data file can be loaded to ensure this variable
+    // points to a reasonable place
+    {
+        ifstream testfile(string(getenv("ARA_SIM_DIR"))+"/data/filter.csv"); 
+        if(!testfile.good()) {
+            throw runtime_error("ARA_SIM_DIR does not point to expected location!");
+        }
+    }
+  
     Settings *settings1 = new Settings();
     settings1->SetGitCommitHash();
 

--- a/IceModel.h
+++ b/IceModel.h
@@ -14,7 +14,8 @@ class Settings;
 //Constants relating to all ice models
 const double FIRNDEPTH=-150.;                // depth of the firn, in meters: currently a constant over all ice
 // input files for Crust 2.0
-const string crust20_in= string(getenv("ARA_SIM_DIR")) + "/data/outcr"; // Crust 2.0 data
+const char* const ara_sim_dir = getenv("ARA_SIM_DIR"); // capture the pointer before converting to string to avoid crash
+const string crust20_in= (ara_sim_dir? string(ara_sim_dir) : "") + "/data/outcr"; // Crust 2.0 data
 const string crust20_out="altitudes.txt"; // output file for plotting
 
 class IceModel : public EarthModel {


### PR DESCRIPTION
This PR adds a check for the existence and sanity of the `ARA_SIM_DIR` environmental variable. When this isn't defined or pointing to a sensible location it can cause crashes (with unhelpful error messages).

This also required a change in how a global variable is defined in `IceModel.h` which would cause a crash upon including since the conversion of the `nullptr` (which `getenv` returns when a variable is undefined) into a `string` would cause a crash before the check could be run in the main code. 