### PR TITLE
Change EVID to 64 bit unsigned int

### DIFF
--- a/Settings.cc
+++ b/Settings.cc
@@ -786,7 +786,8 @@ void Settings::ReadEvtFile(string evtfile){
 
                 std::stringstream iss(line);
 
-                int EL_evid, EL_nuflavorint, EL_nunubar, EL_current, EL_prim_pid;
+                uint64_t EL_evid;
+                int EL_nuflavorint, EL_nunubar, EL_current, EL_prim_pid;
                 double EL_energy, EL_pos_R, EL_pos_theta, EL_pos_phi, EL_dir_theta, EL_dir_phi;
                 double EL_elast_y, EL_weight, EL_prim_energy;
                 if(!(iss >> EL_evid >> EL_nuflavorint >> EL_nunubar >> EL_energy >> EL_current 

--- a/Settings.h
+++ b/Settings.h
@@ -351,7 +351,7 @@ class Settings
 
 
 //arrays for saving read in event features in EVENT_GENERATION_MODE=1
-        vector<int> EVID;
+        vector<uint64_t> EVID;
         vector<int> NUFLAVORINT;
         vector<int> NUBAR;
         vector<double> PNU;


### PR DESCRIPTION
Updated the data type for EVIDs in event lists to a 64 bit unsigned int, since the old `int` was not large enough to store some event IDs.