### PR TITLE
Defining event_ID for EVENT_GENERATION_MODE not 1

### DIFF
--- a/Event.cc
+++ b/Event.cc
@@ -118,6 +118,8 @@ Event::Event (Settings *settings1, Spectra *spectra1, Primaries *primary1, IceMo
             else{
                 nuflavor = primary1->GetNuFlavor(settings1);
                 nu_nubar = primary1->GetNuNuBar(nuflavor, settings1);
+                event_ID = event_num;
+
 
                 nu_prim_energy = pnu; // Set primary energy to be the particle energy when not reading event lists
 


### PR DESCRIPTION
When not reading the event lists, event ID should be the number of the event being simulated.