### PR TITLE
Compile out "negative depth" cerr recurring statement

### DIFF
--- a/IceModel.cc
+++ b/IceModel.cc
@@ -253,8 +253,9 @@ double IceModel::GetARAIceAttenuLength(double depth) {
 
     // check if depth is positive value
     if ( depth < 0. ) {// whether above the ice or wrong value!
-
-        cerr<<"depth negative! "<<depth<<endl;
+        #ifdef VERBOSE_MODE
+        std::cerr << "depth negative! " << depth << std::endl;
+        #endif
     }
     else {
 
@@ -279,7 +280,9 @@ double IceModel::GetARAIceAttenuLength(double depth) {
 */
 double IceModel::temperature(double z){
   if( z < 0.){
-    cerr<<"depth negative! "<<z<<endl;
+    #ifdef VERBOSE_MODE
+    std::cerr << "depth negative! " << depth << std::endl;
+    #endif
   }
   double temp = (-51.0696) + (0.00267687 * z) + (-1.59061E-08 * pow(z,2.)) + (1.83415E-09 * pow(z,3.));
   return temp;
@@ -298,7 +301,9 @@ double IceModel::temperature(double z){
 double IceModel::GetFreqDepIceAttenuLength(double depth, double freq) {
   double AttenL = 0.0;
   if ( depth < 0. ) {
-    cerr<<"depth negative! "<<depth<<endl;
+    #ifdef VERBOSE_MODE
+    std::cerr << "depth negative! " << depth << std::endl;
+    #endif
   }
   else {
     double t = temperature(depth);

--- a/IceModel.cc
+++ b/IceModel.cc
@@ -281,7 +281,7 @@ double IceModel::GetARAIceAttenuLength(double depth) {
 double IceModel::temperature(double z){
   if( z < 0.){
     #ifdef VERBOSE_MODE
-    std::cerr << "depth negative! " << depth << std::endl;
+    std::cerr << "depth negative! " << z << std::endl;
     #endif
   }
   double temp = (-51.0696) + (0.00267687 * z) + (-1.59061E-08 * pow(z,2.)) + (1.83415E-09 * pow(z,3.));

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,15 @@ SRCSUF = ${SrcSuf}
 
 CXX = g++
 
+# User-configurable flags
+VERBOSE ?= 0  # Default is off unless user sets VERBOSE=1
+
 #Generic and Site Specific Flags
 CXXFLAGS     += $(SYSINCLUDES) $(INC_ARA_UTIL) -DGIT_COMMIT_HASH=\"$(GIT_COMMIT_HASH)\"
 CXXFLAGS		 += -Werror=return-type 
+ifeq ($(VERBOSE), 1)
+  CXXFLAGS += -DVERBOSE_MODE
+endif
 #LDFLAGS      += -L. -g -I$(BOOST_ROOT) $(ROOTLDFLAGS) $(LD_ARA_UTIL) -Wl
 LDFLAGS      += -L. -g -I$(BOOST_ROOT) $(ROOTLDFLAGS) $(LD_ARA_UTIL) -Wl,--no-as-needed
 #,--no-as-needed


### PR DESCRIPTION
Tested it already on `veff_ara3`:

Using

`CXXFLAGS     += $(SYSINCLUDES) $(INC_ARA_UTIL) -DGIT_COMMIT_HASH=\"$(GIT_COMMIT_HASH)\" -DVERBOSE_MODE
`

We get the cerr statement:

```
******
trigger passed at bin 4387  passed ch : 0 (0type) Direct dist btw posnu : 3201.86 noiseID : 0 ViewAngle : 56.3795 LikelyTrigSignal : interaction 0, ray 1
trigger passed at bin 4468  passed ch : 6 (0type) Direct dist btw posnu : 3218.74 noiseID : 0 ViewAngle : 56.9636 LikelyTrigSignal : interaction 0, ray 1
trigger passed at bin 4590  passed ch : 10 (0type) Direct dist btw posnu : 3219.54 noiseID : 0 ViewAngle : 56.9094 LikelyTrigSignal : interaction 0, ray 1
trigger passed at bin 4695  passed ch : 15 (1type) Direct dist btw posnu : 3206.03 noiseID : 0 ViewAngle : 56.9101 LikelyTrigSignal : interaction 0, ray 1
Global_Pass : 4387 evt : 16 added weight : 4.29438e-27
4.29438e-27 : 0

Making useful event
StationID: 3
StationID_AraRoot: 3
************depth negative! -26.2745
depth negative! -26.2745
depth negative! -26.2745
depth negative! -26.2745
depth negative! -26.2636
depth negative! -26.2636
depth negative! -26.2636
depth negative! -26.2636
depth negative! -26.2643
depth negative! -26.2643
depth negative! -26.2643
depth negative! -26.2643
depth negative! -26.2752
depth negative! -26.2752
depth negative! -26.2752
depth negative! -26.2752
*
trigger passed at bin 4655  passed ch : 7 (1type) Direct dist btw posnu : 3120.79 noiseID : 0 ViewAngle : 47.5286 LikelyTrigSignal : interaction 0, ray 0
trigger passed at bin 4418  passed ch : 9 (1type) Direct dist btw posnu : 3102.61 noiseID : 0 ViewAngle : 47.7038 LikelyTrigSignal : interaction 0, ray 0
trigger passed at bin 4412  passed ch : 13 (1type) Direct dist btw posnu : 3097.88 noiseID : 0 ViewAngle : 47.4649 LikelyTrigSignal : interaction 0, ray 0
Global_Pass : 4347 evt : 29 added weight : 8.76793e-08
8.76793e-08 : 0
```

Without the last flag:

`CXXFLAGS     += $(SYSINCLUDES) $(INC_ARA_UTIL) -DGIT_COMMIT_HASH=\"$(GIT_COMMIT_HASH)\"`

We dont:
```

 trigger passed at bin 4387  passed ch : 0 (0type) Direct dist btw posnu : 3201.86 noiseID : 0 ViewAngle : 56.3795 LikelyTrigSignal : interaction 0, ray 1
trigger passed at bin 4468  passed ch : 6 (0type) Direct dist btw posnu : 3218.74 noiseID : 0 ViewAngle : 56.9636 LikelyTrigSignal : interaction 0, ray 1
trigger passed at bin 4590  passed ch : 10 (0type) Direct dist btw posnu : 3219.54 noiseID : 0 ViewAngle : 56.9094 LikelyTrigSignal : interaction 0, ray 1
trigger passed at bin 4695  passed ch : 15 (1type) Direct dist btw posnu : 3206.03 noiseID : 0 ViewAngle : 56.9101 LikelyTrigSignal : interaction 0, ray 1
Global_Pass : 4387 evt : 16 added weight : 4.29438e-27
4.29438e-27 : 0

Making useful event
StationID: 3
StationID_AraRoot: 3
*************
trigger passed at bin 4655  passed ch : 7 (1type) Direct dist btw posnu : 3120.79 noiseID : 0 ViewAngle : 47.5286 LikelyTrigSignal : interaction 0, ray 0
trigger passed at bin 4418  passed ch : 9 (1type) Direct dist btw posnu : 3102.61 noiseID : 0 ViewAngle : 47.7038 LikelyTrigSignal : interaction 0, ray 0
trigger passed at bin 4412  passed ch : 13 (1type) Direct dist btw posnu : 3097.88 noiseID : 0 ViewAngle : 47.4649 LikelyTrigSignal : interaction 0, ray 0
Global_Pass : 4347 evt : 29 added weight : 8.76793e-08

```