### PR TITLE
Readout/Trigger Consistency

### DIFF
--- a/Report.cc
+++ b/Report.cc
@@ -1927,7 +1927,7 @@ void Report::triggerCheck_ScanMode0(
                             N_pass_H++;
                         }
                         if (last_trig_bin < this_bin + trig_bin) 
-                            last_trig_bin = this_bin + trig_bin;   // added for fixed V_mimic
+                            last_trig_bin = this_bin + trig_bin + offset;   // added for fixed V_mimic
                         trig_bin = trig_window_bin; // if confirmed this channel passed the trigger, no need to do rest of bins
                         Passed_chs.push_back(antenna_counter);
 


### PR DESCRIPTION
When adding cable delays for triggering (enableTriggerDelays = 0 in ARAAqcd.config in the DAQ, also delay-enable = 0 in configuration files for analysis), the `this_bin + trig_bin` is shifted by a cable delay `offset` in AraSim for the triggering decision.

This was missed in the readout, causing waveforms to show signals near the end of waveforms. This PR fixes it. E.g.

**BEFORE FIX:**

<img width="882" alt="Screenshot 2025-05-26 at 4 45 40 PM" src="https://github.com/user-attachments/assets/c4d7cf94-d0ff-4245-bdb9-99a00a86ee2d" />

**AFTER FIX:**

<img width="883" alt="Screenshot 2025-05-26 at 4 45 27 PM" src="https://github.com/user-attachments/assets/99f03c5c-8510-484f-a34e-4938279db826" />
