### PR TITLE
Ensure PA always triggers in noise only mode

### DIFF
--- a/AraSim.cc
+++ b/AraSim.cc
@@ -725,7 +725,7 @@ void save_event_data(
     for (int i=0; i< report->stations.size(); i++) {
         
         // check the total global trigger passed
-        if (report->stations[i].Global_Pass) {
+        if (report->stations[i].Global_Pass >= 0) {
 
             event->inu_passed = Events_Passed;  
 
@@ -817,7 +817,7 @@ void save_useful_event(
             stationIndex = 0;
         }
 
-        if (report->stations[stationIndex].Global_Pass) {
+        if (report->stations[stationIndex].Global_Pass >= 0) {
             cout << endl << "Making useful event" << endl;
             report->MakeUsefulEvent(detector, settings1, trigger, stationID, stationIndex, theAtriEvent);
         }

--- a/Report.cc
+++ b/Report.cc
@@ -595,8 +595,9 @@ void Report::BuildAndTriggerOnWaveforms(
     // TRIG_ANALYSIS_MODE=2 is the noise-only mode, 
     //   say that all antennas have good signal and have a ray solution if not assigned
     ants_with_nonzero_signal = 16;
-    if(stations[station_index].Total_ray_sol == 0)
+    if(stations[station_index].Total_ray_sol == 0) {
         stations[station_index].Total_ray_sol = 16;
+    }
   }
   else {
     // If rays connected to the station, count how many antennas 

--- a/Report.h
+++ b/Report.h
@@ -156,7 +156,7 @@ class Station_r {
         double max_arrival_time;    // for each station, maximum arrival time (include all ray_solves). this will be used for time delay between antennas.
         double max_PeakV;           // for each station, maximum PeakV value (include all ray_solves). this will also be used for time delay plot (to set same vertical scale)
         int Total_ray_sol;          // total number of ray_sols in the stations. If there is 0 Total_ray_sol, we don't need to do trigger check while there is any Total_ray_sol, we do trigger check.
-        int Global_Pass;            // if global trigger passed or not: 0 = not passed, >0 passed, number indicates the first bin in the triggered window of the waveform at which the global trigger passed
+        int Global_Pass;            // if global trigger passed or not: -1 = not passed, >=0 passed, number indicates the first bin in the triggered window of the waveform at which the global trigger passed
 
         int total_trig_search_bin;  // total number of bins for searching trigger. 
         int next_trig_search_init; // if not -1, designates the next global bin to begin a trigger search from
@@ -439,12 +439,12 @@ class Report {
         double init_T; // locate zero time at the middle and give random time shift (for interpolated waveforms)
 
         // Phased Array variables
-        double pa_force_trigger_snr = 3.5; 
-            // SNR that should always trigger, 
-            // used (eg) when triggering on noise only events
         double pa_snr_cap = 25.;
             // KAH thinks this is the max SNR she had efficiencies calculated for
             // KAH says the PA has a SNR cap of 25 in practice and may have a link showing this.
+        double pa_force_trigger_snr = pa_snr_cap; 
+            // SNR that should always trigger, 
+            // used (eg) when triggering on noise only events
 
         ClassDef(Report,1);
 


### PR DESCRIPTION
This PR adds additional logic to ensure triggers are forced when in noise-only mode for PA. It does not affect how the noise-only case is handled for the normal ARA trigger. 

The trigger is forced by hardcoding the SNR to a large value where the trigger efficiency is 1. Other changes were made to ensure thrown events are not skipped due to a lack of ray trace solutions (from the neutrinos that are generated and then ignored). The current PA trigger implementation is not capable of simulating real RF triggers from noise (since it is based on the signal-only SNR).