### PR TITLE
Change condition to use doVerticalTrace

### DIFF
--- a/RayTrace.cc
+++ b/RayTrace.cc
@@ -1319,7 +1319,7 @@ namespace RayTrace{
                         }
 		bool fullyContained=(sourcePos.GetZ()<=0.0 && targetPos.GetZ()<=0.0); //whether the ray is entirely inside the ice
 		double xy_dist = sqrt((targetPos.GetX()-sourcePos.GetX())*(targetPos.GetX()-sourcePos.GetX())
-												+(targetPos.GetY()-sourcePos.GetY())*(targetPos.GetY()-sourcePos.GetY()));
+									+(targetPos.GetY()-sourcePos.GetY())*(targetPos.GetY()-sourcePos.GetY()));
 		double z_dist = std::abs(targetPos.GetZ()-sourcePos.GetZ());
 		double tanThetaThreshold = std::tan(2.0*M_PI / 180.0); // threshold for using doVerticalTrace is 2 degrees from vertical
 		rayTargetRecord target(targetPos.GetZ(),xy_dist);

--- a/RayTrace.cc
+++ b/RayTrace.cc
@@ -1318,12 +1318,14 @@ namespace RayTrace{
 			return(results);
                         }
 		bool fullyContained=(sourcePos.GetZ()<=0.0 && targetPos.GetZ()<=0.0); //whether the ray is entirely inside the ice
-		double dist = sqrt((targetPos.GetX()-sourcePos.GetX())*(targetPos.GetX()-sourcePos.GetX())+(targetPos.GetY()-sourcePos.GetY())*(targetPos.GetY()-sourcePos.GetY()));
-		rayTargetRecord target(targetPos.GetZ(),dist);
+		double xy_dist = sqrt((targetPos.GetX()-sourcePos.GetX())*(targetPos.GetX()-sourcePos.GetX())+(targetPos.GetY()-sourcePos.GetY())*(targetPos.GetY()-sourcePos.GetY()));
+    double z_dist = std::abs(targetPos.GetZ()-sourcePos.GetZ());
+    double tanThetaThreshold = std::tan(2.0*M_PI / 180.0); // threshold for using doVerticalTrace is 2 degrees from vertical
+		rayTargetRecord target(targetPos.GetZ(),xy_dist);
 		bool dualDirect=false; //whether there are knwon to be two direct solution rays
 		
 		//special case for pesky near-vertical rays
-		if(dist<=requiredAccuracy){
+		if(z_dist > 0. && xy_dist/z_dist <= tanThetaThreshold){
 			
                     // changed
                     //std::cout << "Computing direct ray (vertical)" << std::endl;
@@ -1403,7 +1405,7 @@ namespace RayTrace{
                 // changed 
                 // both cout
 		//std::cout << "Looking for estimate" << std::endl;
-		indexOfRefractionModel::RayEstimate est=rModel->estimateRayAngle(sourcePos.GetZ(), targetPos.GetZ(), dist); //TODO: put this back!!!
+		indexOfRefractionModel::RayEstimate est=rModel->estimateRayAngle(sourcePos.GetZ(), targetPos.GetZ(), xy_dist); //TODO: put this back!!!
 		//std::cout << "Estimate result : " << est.status << " refractionmodel solution : "<< indexOfRefractionModel::SOLUTION << std::endl;
 
 

--- a/RayTrace.cc
+++ b/RayTrace.cc
@@ -1319,7 +1319,7 @@ namespace RayTrace{
                         }
 		bool fullyContained=(sourcePos.GetZ()<=0.0 && targetPos.GetZ()<=0.0); //whether the ray is entirely inside the ice
 		double xy_dist = sqrt((targetPos.GetX()-sourcePos.GetX())*(targetPos.GetX()-sourcePos.GetX())
-									+(targetPos.GetY()-sourcePos.GetY())*(targetPos.GetY()-sourcePos.GetY()));
+							+(targetPos.GetY()-sourcePos.GetY())*(targetPos.GetY()-sourcePos.GetY()));
 		double z_dist = std::abs(targetPos.GetZ()-sourcePos.GetZ());
 		double tanThetaThreshold = std::tan(2.0*M_PI / 180.0); // threshold for using doVerticalTrace is 2 degrees from vertical
 		rayTargetRecord target(targetPos.GetZ(),xy_dist);

--- a/RayTrace.cc
+++ b/RayTrace.cc
@@ -1319,8 +1319,8 @@ namespace RayTrace{
                         }
 		bool fullyContained=(sourcePos.GetZ()<=0.0 && targetPos.GetZ()<=0.0); //whether the ray is entirely inside the ice
 		double xy_dist = sqrt((targetPos.GetX()-sourcePos.GetX())*(targetPos.GetX()-sourcePos.GetX())+(targetPos.GetY()-sourcePos.GetY())*(targetPos.GetY()-sourcePos.GetY()));
-    double z_dist = std::abs(targetPos.GetZ()-sourcePos.GetZ());
-    double tanThetaThreshold = std::tan(2.0*M_PI / 180.0); // threshold for using doVerticalTrace is 2 degrees from vertical
+		double z_dist = std::abs(targetPos.GetZ()-sourcePos.GetZ());
+		double tanThetaThreshold = std::tan(2.0*M_PI / 180.0); // threshold for using doVerticalTrace is 2 degrees from vertical
 		rayTargetRecord target(targetPos.GetZ(),xy_dist);
 		bool dualDirect=false; //whether there are knwon to be two direct solution rays
 		

--- a/RayTrace.cc
+++ b/RayTrace.cc
@@ -1318,14 +1318,15 @@ namespace RayTrace{
 			return(results);
                         }
 		bool fullyContained=(sourcePos.GetZ()<=0.0 && targetPos.GetZ()<=0.0); //whether the ray is entirely inside the ice
-		double xy_dist = sqrt((targetPos.GetX()-sourcePos.GetX())*(targetPos.GetX()-sourcePos.GetX())+(targetPos.GetY()-sourcePos.GetY())*(targetPos.GetY()-sourcePos.GetY()));
+		double xy_dist = sqrt((targetPos.GetX()-sourcePos.GetX())*(targetPos.GetX()-sourcePos.GetX())
+												+(targetPos.GetY()-sourcePos.GetY())*(targetPos.GetY()-sourcePos.GetY()));
 		double z_dist = std::abs(targetPos.GetZ()-sourcePos.GetZ());
 		double tanThetaThreshold = std::tan(2.0*M_PI / 180.0); // threshold for using doVerticalTrace is 2 degrees from vertical
 		rayTargetRecord target(targetPos.GetZ(),xy_dist);
 		bool dualDirect=false; //whether there are knwon to be two direct solution rays
 		
 		//special case for pesky near-vertical rays
-		if(z_dist > 0. && xy_dist/z_dist <= tanThetaThreshold){
+		if((z_dist > 0.) && (xy_dist/z_dist <= tanThetaThreshold)){
 			
                     // changed
                     //std::cout << "Computing direct ray (vertical)" << std::endl;


### PR DESCRIPTION
This PR changes the condition to use the ray tracer aimed at near-vertical solutions, `doVerticalTrace`. 

Previously, this function was used when the x-y distance between the target and source was smaller than the `requiredAccuracy` (usually 0.2 meters). This condition was independent of the z-coordinate, so that even very nearly vertical sources (eg 0.7 m in x-y but 1.5 km in z) did not satisfy the condition, resulting in very slow ray tracing using `doTrace`. 

We've updated this to use `doVerticalTrace` whenever the angle from the target's z-axis to the source is within 2 degrees of vertical. This should be more robust in terms of performance without affecting the ray tracing accuracy.