### PR TITLE
Give receivers and transmitters their own index of refraction

### DIFF
--- a/Detector.h
+++ b/Detector.h
@@ -252,6 +252,7 @@ class Detector {
         vector<double> TxFreq;
         vector<vector<double> > Txgain;
         vector<vector<double> > Txphase;
+        double Txantenna_source_medium_n;    
         void ReadImpedance(string filename, vector<double> *TempRealImpedance, vector<double> *TempImagImpedance);
         void ReadAllAntennaImpedance(Settings *settings1);
 


### PR DESCRIPTION
This PR gives transmitter and receiver antennas their own indexes of refraction, but still assumes all receivers/transmitters share the same index. This also adds some sanity checks to make sure thats true, but only for receivers since the code currently only supports a single transmitter type at a time.

**Testing summary**
A3 veff test: passed ✅
birefringence veff test: passed ✅
pa veff test: passed ✅
pulser veff test: passed ✅