### PR TITLE
Fix PA noise sim triggers.

### DIFF
--- a/Report.cc
+++ b/Report.cc
@@ -5357,7 +5357,7 @@ int Report::get_PA_trigger_bin(
         double avgSnr = 0.;
         if(settings->TRIG_ANALYSIS_MODE == 2) { // Noise only triggers
             avgSnr = pa_force_trigger_snr;
-            return 1; // 0 is interpreted as false downstream, so can't trigger on bin 0 
+            return (waveform_length-trigger_window_bins + 1)/2; // 0 is interpreted as false downstream, so can't trigger on bin 0 
         }
         else { 
             // Estimate average SNR in topmost vpol

--- a/Report.cc
+++ b/Report.cc
@@ -5356,7 +5356,8 @@ int Report::get_PA_trigger_bin(
         // Scale SNR according to full phased array angular response
         double avgSnr = 0.;
         if(settings->TRIG_ANALYSIS_MODE == 2) { // Noise only triggers
-            avgSnr = pa_force_trigger_snr; 
+            avgSnr = pa_force_trigger_snr;
+            return 1; // 0 is interpreted as false downstream, so can't trigger on bin 0 
         }
         else { 
             // Estimate average SNR in topmost vpol


### PR DESCRIPTION
This PR fixes an edge case for noise simulations with PA. This only affects noise simulations on PA.

In noise simulations, the PA is forced to trigger and so its trigger bin is `0`. The trigger bin is assigned to `Global_Pass` which is later tested to determine whether there was a trigger via `if (report->stations[i].Global_Pass)`. The bin of `0` is converted to a boolean `false` and so the noise triggers are never considered successful when it comes time to save the event. We fix this by simply returning the center-most available trigger bin (to avoid edge effects) when in noise simulation mode.

**Testing summary**
A3 veff test: passed ✅ 
birefringence veff test: passed ✅ 
pa veff test: passed ✅ 
pulser veff test: passed ✅ 